### PR TITLE
Add secrets

### DIFF
--- a/SECRETS.md
+++ b/SECRETS.md
@@ -1,0 +1,8 @@
+# Secrets
+
+MapLibre publishes source coded and compiled binaries on several platforms. This document aims to keep track of what secrets we have. The actual secret tokens shall be handled by the members of the MapLibre Governing Board.
+
+* [GitHub MapLibre Organization](https://github.com/maplibre): Governing Board members are [owners](https://docs.github.com/en/organizations/managing-peoples-access-to-your-organization-with-roles/roles-in-an-organization#organization-owners) of the organization.
+* NPM: Some Governing Board members have access to our [maplibreorg](https://www.npmjs.com/~maplibreorg) NPM account.
+* DNS: A Governing Board member manages the domain name https://maplibre.org
+* [opencollective](https://opencollective.com/maplibre): All Governing Board members have admin access.


### PR DESCRIPTION
Adds some documentation about the platforms we have access tokens and secrets for.

Missing here is the native stuff, which I think includes some maven access, GPC for android tests, and maybe some iOS stuff...
