### PR TITLE
Add Voting Members file

### DIFF
--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -1,0 +1,12 @@
+# MapLibre Voting Members
+
+The MapLibre Voting Members elect the Governing Board. Voting Members are people who contributed to MapLibre in a non-trivial way and we intentionally leave the definition of non-trivial to the community to decide. New people can become Voting Members if they are nominated by a Voting Member and are subsequently elected by a majority of the Voting Members. A single organization can have at most 3 MapLibre Voting Members because we aim for a broad community representation.
+
+## List of Voting Members
+
+The Voting Members, in alphabetic order by their GitHub handles, are:
+
+@klokan
+@lseelenbinder
+@nyurik
+@wipfli


### PR DESCRIPTION
The MapLibre Governing Board decided yesterday to have a public list of Voting Members. This pull request adds a file to track who is a Voting Member.                     

To bootstrap the election process, the Governing Board chose a set of people who can become Voting Member straight away. I will publish this list once this pull request is merged...
