### PR TITLE
Add JannikGM to voting members

### DIFF
--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -26,6 +26,8 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@hoeflehner](https://github.com/hoeflehner)
 
+[@JannikGM](https://github.com/JannikGM)
+
 [@Joxit](https://github.com/Joxit)
 
 [@jutaz](https://github.com/jutaz)


### PR DESCRIPTION
Added myself as per #36 invitation.

Note my thoughts on incomplete information regarding members / organizations: https://github.com/maplibre/maplibre/issues/36#issuecomment-1182996345.
I could probably also add our companies GitHub organization as a proxy voting member, if that is preferred.