### PR TITLE
add nreese to MapLibre Voting Members

### DIFF
--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -56,6 +56,8 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@ntadej](https://github.com/ntadej)
 
+[@nreese](https://github.com/nreese)
+
 [@nvanfleet](https://github.com/nvanfleet)
 
 [@nyurik](https://github.com/nyurik)


### PR DESCRIPTION
Following instructions to accept invitation to become voting member of Maplibre.