### PR TITLE
Create security policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-repo-checklist.md
+++ b/.github/ISSUE_TEMPLATE/new-repo-checklist.md
@@ -25,6 +25,12 @@ https://github.com/maplibre/[repo]
   *Description, link to the main maplibre.org page, name of the OSM-US Slack channel for discussions and an [invite link](https://osmus-slack.herokuapp.com/), etc*
 - [ ] `/LICENSE`
    *Dual-licensed repos may have additional files like `LICENSE-MIT` and `LICENSE-APACHE`*
+- [ ] `/SECURITY_POLICY.txt`
+    Add the text:
+    ```
+    For an up-to-date policy refer to
+    https://github.com/maplibre/maplibre/blob/main/SECURITY_POLICY.txt
+    ```
 - [ ] `/CONTRIBUTING.md`
 - [ ] The repo has Pull Request and Issue Templates in `/.github` dir.
 - [ ] The repo has `/.github/FUNDING.yml` file copied from [maplibre-gl-js/funding](https://github.com/maplibre/maplibre-gl-js/blob/main/.github/FUNDING.yml)

--- a/SECURITY_POLICY.txt
+++ b/SECURITY_POLICY.txt
@@ -38,8 +38,8 @@ it reports one of the following problems:
 
 4. Reporting Vulnerabilities
 
-Report vulnerabilities via e-mail to security@maplibre.org. For
-encryption the PGP key https://example.com/pubkey.asc can be used.
+Report vulnerabilities via e-mail to security@maplibre.org. MapLibre does not 
+offer a GPG key for encryption.
 
 Please make sure that you include the following information:
 - Which service is affected

--- a/SECURITY_POLICY.txt
+++ b/SECURITY_POLICY.txt
@@ -1,0 +1,75 @@
+MapLibre Security and Vulnerability Reporting Policy
+
+1. Services Covered by this Policy
+
+This policy covers all services directly operated by us (MapLibre).
+Services can be identified by the following means:
+- The website has a .well-known/security.txt that links to this policy.
+- The reverse DNS of an IP address resolves to one of the following
+  domain (or subdomains): maplibre.org
+
+2. Acceptable Use
+
+We generally invite security researchers to search for vulnerabilities
+in our services. We kindly ask to not put any actual user data or
+production systems at risk.
+
+3. Classification of Vulnerabilities
+
+We will consider a vulnerability report most likely as relevant if it
+reports one of the following problems:
+- Memory-safety issues in any MapLibre project
+- The vulnerability can be used to directly access non-public
+  information that either reveals further security relevant problems or
+  contains user data, credentials, or sensitive data in general.
+- The vulnerability can be used to disrupt the orderly operation of a
+  service (Denial of Service).
+- The vulnerability can be used to manipulate data within the service.
+- XSS, CSRF, RCE, authentication/authorization bypass, SQL inections,
+  etc are considered relevant.
+
+We will consider a vulnerability report most likely as NOT relevant if
+it reports one of the following problems:
+- Missing security features, for example HTTP headers, if they are not
+  actually preventing a vulnerability.
+- Publicly accessible version strings of used software.
+- Security vulnerablities that can only be used within the scope of the
+  used account.
+
+4. Reporting Vulnerabilities
+
+Report vulnerabilities via e-mail to security@maplibre.org. For
+encryption the PGP key https://example.com/pubkey.asc can be used.
+
+Please make sure that you include the following information:
+- Which service is affected
+- How can the bug be used/exploited
+- Explanation of the risk
+
+Reports will be answered within 48 hours. If you have not received an
+answer within that time frame, feel free to contact us again.
+
+For used open source software, we recommend to file bug reports and/or
+pull requests against the upstream repositories. This includes hardening
+instructions in the installation documentation.
+
+5. Bug Bounties / Vulnerability Rewards
+
+The amount of the reward payed depends on the severity of the found
+vulnerability. We usually do not pay rewards if vulnerabilities can be
+found in mass scans with of-the-shelf software.
+
+Only responsible disclosures are eligible for rewards.
+
+6. Acknowledgement
+
+We list recognized reports of vulnerablities online if the reporting
+security researcher agrees. The name, contact e-mail address, and type
+of vulnerability can be included in the list. Our public
+acknowledgements can be found at
+https://example.com/security-acknowledgements.html.
+
+7. About this Policy
+
+This policy is MIT licensed. Feel free to suggest modifications and
+additions at https://github.com/digitalfabrik/security-policy.

--- a/SECURITY_POLICY.txt
+++ b/SECURITY_POLICY.txt
@@ -55,11 +55,7 @@ instructions in the installation documentation.
 
 5. Bug Bounties / Vulnerability Rewards
 
-The amount of the reward payed depends on the severity of the found
-vulnerability. We usually do not pay rewards if vulnerabilities can be
-found in mass scans with of-the-shelf software.
-
-Only responsible disclosures are eligible for rewards.
+The MapLibre project does not currently pay rewards.
 
 6. Acknowledgement
 


### PR DESCRIPTION
This establishes a security policy for maplibre projects.
That way we encourage security researchers to have a look at our projects.

* This file will be referenced from https://maplibre.org/.well-known/security.txt
* This file will also be referenced from any repository which hosts a non-experimental project.