### PR TITLE
Add a description of project tiers

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-repo-checklist.md
+++ b/.github/ISSUE_TEMPLATE/new-repo-checklist.md
@@ -58,7 +58,6 @@ https://github.com/maplibre/[repo]
 - [ ] Grant admin rights to the board members and automation accounts for packages <list-of-packages>
   - [npmjs.com](https://www.npmjs.com/): package settings / invite:  `maplibreorg nyurik klokan lseelenbinder wipfli`
   - [crates.io](https://crates.io/): package settings / add owner: `nyurik klokan lseelenbinder wipfli`
-- [ ] The new repo has been added to [PROJECT_TIERS.md](https://github.com/maplibre/maplibre/blob/main/PROJECT_TIERS.md)
 
 ## Community
 - [ ] The new repo has been announced in the `#maplibre` OSMUS slack channel.

--- a/.github/ISSUE_TEMPLATE/new-repo-checklist.md
+++ b/.github/ISSUE_TEMPLATE/new-repo-checklist.md
@@ -58,6 +58,7 @@ https://github.com/maplibre/[repo]
 - [ ] Grant admin rights to the board members and automation accounts for packages <list-of-packages>
   - [npmjs.com](https://www.npmjs.com/): package settings / invite:  `maplibreorg nyurik klokan lseelenbinder wipfli`
   - [crates.io](https://crates.io/): package settings / add owner: `nyurik klokan lseelenbinder wipfli`
+- [ ] The new repo has been added to [PROJECT_TIERS.md](https://github.com/maplibre/maplibre/blob/main/PROJECT_TIERS.md)
 
 ## Community
 - [ ] The new repo has been announced in the `#maplibre` OSMUS slack channel.

--- a/PROJECT_TIERS.md
+++ b/PROJECT_TIERS.md
@@ -2,7 +2,7 @@
 
 The MapLibre Organization maintains the map rendering frameworks MapLibre GL JS and MapLibre GL Native and fosters an ecosystem of plugins and tools around these libraries to produce the best maps in the world.
 
-The three project tiers Core, Supported, and Hosted describe qualitatively how donated resources are distributed among the projects.
+The three project tiers Core, Supported, and Hosted describe qualitatively how organization resources are distributed among the projects.
 
 ## Tiers
 

--- a/PROJECT_TIERS.md
+++ b/PROJECT_TIERS.md
@@ -12,7 +12,7 @@ A project that the MapLibre Organization is committed to in a long-term way. A s
 
 ### Supported Project
 
-A project that the MapLibre Organization can allocate funding to in the form of paid Bounties. Supported Projects receive a substantially smaller amount of funding than Core Projects and the MapLibre Organization cannot guarantee any level of long-term support.
+A project that the MapLibre Organization can allocate resources to in the form of paid Bounties. Supported Projects receive a substantially smaller amount of resources than Core Projects and the MapLibre Organization does not guarantee any level of long-term support.
 
 ### Hosted Project
 

--- a/PROJECT_TIERS.md
+++ b/PROJECT_TIERS.md
@@ -8,7 +8,7 @@ The three project tiers Core, Supported, and Hosted describe qualitatively how d
 
 ### Core Project
 
-A project that the MapLibre Organization is committed to in a long-term way. A substantial amount of funding is spent on the project in the form of paid Maintainer time and paid Bounties to ensure its long-term success.
+A project that the MapLibre Organization is committed to long-term. A substantial amount of resources is allocated to the project in the form of paid Maintainer time and paid Bounties to ensure its long-term success.
 
 ### Supported Project
 

--- a/PROJECT_TIERS.md
+++ b/PROJECT_TIERS.md
@@ -20,11 +20,11 @@ A project that the MapLibre Organization does not allocate any funding to. The p
 
 ## Process
 
-New projects start in the Hosted tier. 
+New projects start in the Hosted tier.
 
 If you would like to propose to change the tier of a project, please edit this file in a pull request.
 
-Changing the tier of a project requires approval by the MapLibre Governing Board, as the Board is responsible for all financial decisions. 
+Changing the tier of a project requires approval by the MapLibre Governing Board, as the Board is responsible for all financial decisions.
 
 ## List of Projects
 

--- a/PROJECT_TIERS.md
+++ b/PROJECT_TIERS.md
@@ -12,7 +12,7 @@ A project that the MapLibre Organization is committed to in a long-term way. A s
 
 ### Supported Project
 
-A project that the MapLibre Organization can allocate funding to in the form of paid Maintainer time and paid Bounties. Supported Projects receive a substantially smaller amount of funding than Core Projects and the MapLibre Organization cannot guarantee any level of long-term support.
+A project that the MapLibre Organization can allocate funding to in the form of paid Bounties. Supported Projects receive a substantially smaller amount of funding than Core Projects and the MapLibre Organization cannot guarantee any level of long-term support.
 
 ### Hosted Project
 
@@ -31,7 +31,10 @@ Changing the tier of a project requires approval by the MapLibre Governing Board
 ### Core
 
 * [maplibre-gl-js](https://github.com/maplibre/maplibre-gl-js)
+* [maplibre-gl-js-docs](https://github.com/maplibre/maplibre-gl-js-docs)
 * [maplibre-gl-native](https://github.com/maplibre/maplibre-gl-native)
+* [maplibre-native-base](https://github.com/maplibre/maplibre-native-base)
+* [maplibre-java](https://github.com/maplibre/maplibre-java)
 
 ### Supported
 
@@ -39,25 +42,4 @@ Changing the tier of a project requires approval by the MapLibre Governing Board
 
 ### Hosted
 
-* [maplibre-gl-native-boost](https://github.com/maplibre/maplibre-gl-native-boost)
-* [mbtileserver-rs](https://github.com/maplibre/mbtileserver-rs)
-* [maplibre-plugins-android](https://github.com/maplibre/maplibre-plugins-android)
-* [demotiles](https://github.com/maplibre/demotiles)
-* [maplibre-gl-native-distribution](https://github.com/maplibre/maplibre-gl-native-distribution)
-* [maplibre-gl-directions](https://github.com/maplibre/maplibre-gl-directions)
-* [martin-landing-page](https://github.com/maplibre/martin-landing-page)
-* [maplibre-native-base](https://github.com/maplibre/maplibre-native-base)
-* [maplibre.github.io](https://github.com/maplibre/maplibre.github.io)
-* [awesome-maplibre](https://github.com/maplibre/awesome-maplibre)
-* [qt-geoservices-maplibre-gl](https://github.com/maplibre/qt-geoservices-maplibre-gl)
-* [font-maker](https://github.com/maplibre/font-maker)
-* [maplibre-react-native](https://github.com/maplibre/maplibre-react-native)
-* [maplibre-gl-leaflet](https://github.com/maplibre/maplibre-gl-leaflet)
-* [maplibre-navigation-android](https://github.com/maplibre/maplibre-navigation-android)
-* [maplibre-gl-geocoder](https://github.com/maplibre/maplibre-gl-geocoder)
-* [maplibre-gl-js-docs](https://github.com/maplibre/maplibre-gl-js-docs)
-* [ngx-maplibre-gl](https://github.com/maplibre/ngx-maplibre-gl)
-* [maplibre-gl-compare](https://github.com/maplibre/maplibre-gl-compare)
-* [maplibre-java](https://github.com/maplibre/maplibre-java)
-* [martin](https://github.com/maplibre/martin)
-* [maplibre-rs](https://github.com/maplibre/maplibre-rs)
+* All projects in the [MapLibre GitHub organization](https://github.com/maplibre/) which are not in the Core or Supported tier.

--- a/PROJECT_TIERS.md
+++ b/PROJECT_TIERS.md
@@ -1,0 +1,63 @@
+# Project Tiers
+
+The MapLibre Organization maintains the map rendering frameworks MapLibre GL JS and MapLibre GL Native and fosters an ecosystem of plugins and tools around these libraries to produce the best maps in the world.
+
+The three project tiers Core, Supported, and Hosted describe qualitatively how donated resources are distributed among the projects.
+
+## Tiers
+
+### Core Project
+
+A project that the MapLibre Organization is committed to in a long-term way. A substantial amount of funding is spent on the project in the form of paid Maintainer time and paid Bounties to ensure its long-term success.
+
+### Supported Project
+
+A project that the MapLibre Organization can allocate funding to in the form of paid Maintainer time and paid Bounties. Supported Projects receive a substantially smaller amount of funding than Core Projects and the MapLibre Organization cannot guarantee any level of long-term support.
+
+### Hosted Project
+
+A project that the MapLibre Organization does not allocate any funding to. The project is hosted in the MapLibre GitHub organization to facilitate collaboration between the people who are interested in the project.
+
+## Process
+
+New projects start in the Hosted tier. 
+
+If you would like to propose to change the tier of a project, please edit this file in a pull request.
+
+Changing the tier of a project requires approval by the MapLibre Governing Board, as the Board is responsible for all financial decisions. 
+
+## List of Projects
+
+### Core
+
+* [maplibre-gl-js](https://github.com/maplibre/maplibre-gl-js)
+* [maplibre-gl-native](https://github.com/maplibre/maplibre-gl-native)
+
+### Supported
+
+* Currently none.
+
+### Hosted
+
+* [maplibre-gl-native-boost](https://github.com/maplibre/maplibre-gl-native-boost)
+* [mbtileserver-rs](https://github.com/maplibre/mbtileserver-rs)
+* [maplibre-plugins-android](https://github.com/maplibre/maplibre-plugins-android)
+* [demotiles](https://github.com/maplibre/demotiles)
+* [maplibre-gl-native-distribution](https://github.com/maplibre/maplibre-gl-native-distribution)
+* [maplibre-gl-directions](https://github.com/maplibre/maplibre-gl-directions)
+* [martin-landing-page](https://github.com/maplibre/martin-landing-page)
+* [maplibre-native-base](https://github.com/maplibre/maplibre-native-base)
+* [maplibre.github.io](https://github.com/maplibre/maplibre.github.io)
+* [awesome-maplibre](https://github.com/maplibre/awesome-maplibre)
+* [qt-geoservices-maplibre-gl](https://github.com/maplibre/qt-geoservices-maplibre-gl)
+* [font-maker](https://github.com/maplibre/font-maker)
+* [maplibre-react-native](https://github.com/maplibre/maplibre-react-native)
+* [maplibre-gl-leaflet](https://github.com/maplibre/maplibre-gl-leaflet)
+* [maplibre-navigation-android](https://github.com/maplibre/maplibre-navigation-android)
+* [maplibre-gl-geocoder](https://github.com/maplibre/maplibre-gl-geocoder)
+* [maplibre-gl-js-docs](https://github.com/maplibre/maplibre-gl-js-docs)
+* [ngx-maplibre-gl](https://github.com/maplibre/ngx-maplibre-gl)
+* [maplibre-gl-compare](https://github.com/maplibre/maplibre-gl-compare)
+* [maplibre-java](https://github.com/maplibre/maplibre-java)
+* [martin](https://github.com/maplibre/martin)
+* [maplibre-rs](https://github.com/maplibre/maplibre-rs)

--- a/PROJECT_TIERS.md
+++ b/PROJECT_TIERS.md
@@ -16,7 +16,7 @@ A project that the MapLibre Organization can allocate funding to in the form of 
 
 ### Hosted Project
 
-A project that the MapLibre Organization does not allocate any funding to. The project is hosted in the MapLibre GitHub organization to facilitate collaboration between the people who are interested in the project.
+A project that the MapLibre Organization does not allocate any resources to. The project is hosted in the MapLibre GitHub organization to facilitate collaboration between the people who are interested in the project.
 
 ## Process
 


### PR DESCRIPTION
Adds a description of the project tiers together with an initial list of projects.

I propose to start with this list, and then make individual pull requests to the file to promote projects from the Hosted tier to the Supported tier.