### PR TITLE
Add maplibre-plugins-android (Annotations) as a Core project

### DIFF
--- a/PROJECT_TIERS.md
+++ b/PROJECT_TIERS.md
@@ -35,7 +35,7 @@ Changing the tier of a project requires approval by the MapLibre Governing Board
 * [maplibre-gl-native](https://github.com/maplibre/maplibre-gl-native)
 * [maplibre-native-base](https://github.com/maplibre/maplibre-native-base)
 * [maplibre-plugins-android](https://github.com/maplibre/maplibre-plugins-android)
-  * [Annotations](https://github.com/maplibre/maplibre-plugins-android/tree/master/plugin-annotation): Core
+  * [Annotations](https://github.com/maplibre/maplibre-plugins-android/tree/main/plugin-annotation): Core
   * Other plugins: Hosted
 * [maplibre-java](https://github.com/maplibre/maplibre-java)
 

--- a/PROJECT_TIERS.md
+++ b/PROJECT_TIERS.md
@@ -35,7 +35,7 @@ Changing the tier of a project requires approval by the MapLibre Governing Board
 * [maplibre-gl-native](https://github.com/maplibre/maplibre-gl-native)
 * [maplibre-native-base](https://github.com/maplibre/maplibre-native-base)
 * [maplibre-plugins-android](https://github.com/maplibre/maplibre-plugins-android)
-  * [annotation-plugin](https://github.com/maplibre/maplibre-plugins-android/tree/master/plugin-annotation): Core
+  * [Annotations](https://github.com/maplibre/maplibre-plugins-android/tree/master/plugin-annotation): Core
   * Other plugins: Hosted
 * [maplibre-java](https://github.com/maplibre/maplibre-java)
 

--- a/PROJECT_TIERS.md
+++ b/PROJECT_TIERS.md
@@ -34,6 +34,9 @@ Changing the tier of a project requires approval by the MapLibre Governing Board
 * [maplibre-gl-js-docs](https://github.com/maplibre/maplibre-gl-js-docs)
 * [maplibre-gl-native](https://github.com/maplibre/maplibre-gl-native)
 * [maplibre-native-base](https://github.com/maplibre/maplibre-native-base)
+* [maplibre-plugins-android](https://github.com/maplibre/maplibre-plugins-android)
+  * [annotation-plugin](https://github.com/maplibre/maplibre-plugins-android/tree/master/plugin-annotation): Core
+  * Other plugins: Hosted
 * [maplibre-java](https://github.com/maplibre/maplibre-java)
 
 ### Supported


### PR DESCRIPTION
This PR makes [maplibre-plugins-android](https://github.com/maplibre/maplibre-plugins-android), specifically the [Annotations](https://github.com/maplibre/maplibre-plugins-android/tree/main/plugin-annotation) plugin, a core project. The other plugins remain 'Hosted' (for now). Annotations are currently part of maplibre-gl-native, but they were deprecated by Mapbox before the fork.

Thanks @fynngodau for sharing his thoughts on the [discussion thread](https://github.com/maplibre/maplibre/discussions/186#discussioncomment-4786133). 

> My perspective on the `maplibre-plugins-android` repository is as follows. Specifically I have been working with the annotations plugin.
> 
> Built separately from MapLibre itself, it obviously doesn't include any features that couldn't be implemented by a developer themselves. However, a user of the SDK would expect "convenience" functions such as "add marker to map" to be readily available. Such functions are also available in MapLibre (partially with duplicate code – once written to imitate Google Maps' API), however they are all deprecated in favor of the annotations plugin.
> 
> I would recommend the following plan:
> 
>     * remove deprecated annotation functionality from Android's maplibre-gl-native
> 
>     * make maplibre-plugins-android a Core project (at least a Supported project)
> 
>     * think about where it is possible to add more convenience and user-friendliness to the annotations plugin, for example through Kotlin extension functions.
> 
> 
> I haven't worked with the other plugins and cannot really comment; it really might make sense to differentiate the tiers per plugin, as some are less important than others.

