### PR TITLE
Add style-spec repo to core tier

### DIFF
--- a/PROJECT_TIERS.md
+++ b/PROJECT_TIERS.md
@@ -39,6 +39,7 @@ Changing the tier of a project requires approval by the MapLibre Governing Board
   * Other plugins: Hosted
 * [maplibre-java](https://github.com/maplibre/maplibre-java)
 * [maplibre-gl-native-distribution](https://github.com/maplibre/maplibre-gl-native-distribution)
+* [maplibre-style-spec](https://github.com/maplibre/maplibre-style-spec)
 
 ### Supported
 


### PR DESCRIPTION
After breaking out the style-spec from maplibre-gl-js, it seems natural to add it in the list of core tier repos.