### PR TITLE
Move maplibre-rs to the sponsored tier

### DIFF
--- a/PROJECT_TIERS.md
+++ b/PROJECT_TIERS.md
@@ -43,7 +43,7 @@ Changing the tier of a project requires approval by the MapLibre Governing Board
 
 ### Supported
 
-* Currently none.
+* [maplibre-rs](https://github.com/maplibre/maplibre-rs)
 
 ### Hosted
 


### PR DESCRIPTION
## Intro to maplibre-rs
maplibre-rs is an R&D effort that tries to answer the question - If MapLibre Native and MapLibre GL JS didn’t exist today, how would we build such a renderer?

What we want from a renderer is:
* High portability - we want the renderer wherever our users are
* High performance - we want to make the most of the hardware
* High maintainability - we want an approachable and small code base

So far the project has been exploring the use of Rust as a language, therefore the -rs name, for the reasons that it’s been hailed as a more memory-safe, thus approachable, language than the intimidating C++/C, while maintaining the high performance of a non-garbage collected language. This is secured through extensive compile checks, known as the borrow checker.

The project has also been exploring using the WebGPU API through the [wgpu project](https://github.com/gfx-rs/wgpu), and eyes are kept on alternatives like the upcoming Rust-first approach to writing shaders, known as [rust-gpu](https://github.com/EmbarkStudios/rust-gpu), as well. Having a single language for our shaders would make the repository more maintainable than having metal/opengl/vulkan(?)/webgpu(?) as is the current approach in MapLibre Native.

The upcoming browser implementations of WebGPU opens the door for us to use a native MapLibre implementation like maplibre-rs or MapLibre Native in the browser. This can be done by compiling native code to webassembly. For Rust, this can be done using rustwasm or sledgehammer. For C++, this can be done with emscripten. This approach will become more feasible as WebAssembly and WebGPU get more capabilities and support in the browsers. The exploration into this area has the potential to one day make our maintenance and feature-parity burdens lower by reducing our offering to a single renderer. The current state of maplibre-rs can already now be executed through this approach in the browser. 

WebGPU - [Demo](https://webgpu.demo.maplibre-rs.maplibre.org/) - latest Chrome only
WebGL - [Demo](https://webgl.demo.maplibre-rs.maplibre.org/)

Here is a [whitepaper](https://doi.org/10.5194/isprs-archives-XLVIII-4-W1-2022-35-2022) with further information 

## What would be a success for maplibre-rs?
maplibre-rs doesn’t have, or even aim to, replace GL JS and Native to be a success. Even if the only tangible result of this R&D effort is an increased community competence in Rust and nascent graphics APIs, that alone would bring long-term value for both GL JS and Native.

## Why does it have to be in the supported tier?
R&D efforts have been voiced as important by our sponsors, because innovation is necessary to stay relevant long-term. This project has come a long way without funding, and putting it in the supported tier is mainly a pre-emptive move to avoid complete stagnation. Lastly, it's a recognition that this effort is likely to bring various kinds of indirect, and maybe even direct, value to our core tier projects Native and GL JS, which our sponsor program is currently centered around.
