### PR TITLE
Add link to TSC Meeting Notes on Google Docs instead of Discussions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Charter, elections, roles & responsibilities, bounties, recruitment, sponsorship
 
 Minutes from:
 
-- [Technical Steeering Commitee meetings](https://github.com/maplibre/maplibre/discussions/categories/technical-steering-committee-meetings)
+- [Technical Steeering Commitee meetings](https://docs.google.com/document/d/1RIHlPLvCzNr6hXXJtMY8uThIAb9nIzeS54KRn79KCHw/edit?usp=sharing)
 - [Governing Board meetings](https://github.com/maplibre/maplibre/discussions/categories/governing-board-meetings)
 - [Advisory Council Meetings](https://github.com/maplibre/maplibre/discussions/categories/advisory-council-meetings).
 


### PR DESCRIPTION
Historically we have been archiving the TSC Meeting Notes on [GitHub](https://github.com/maplibre/maplibre/discussions/categories/technical-steering-committee-meetings). I think this has been used for further discussion after the meetings, but in my opinion those should happen in the relevant discussion threads. It's also a bit easier to link to meeting notes this way, but I have not seen this happen a lot (or at all).

It's more convenient to just keep the notes on Google Docs in my opinion, hence this PR to link to them there.