### PR TITLE
Replace CoC enforcement contact with personal addresses

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,8 @@ representative at an online or offline event.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to any of the following people:
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to any of the following people:
 
 - Harel Mazor (harel.mazor AT gmail DOT com)
 - Birk Skyum (birk.skyum AT pm DOT me)
@@ -68,7 +69,8 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be repor
 
 All complaints will be reviewed and investigated promptly and fairly.
 
-All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
 
 ## Enforcement Guidelines
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -61,11 +61,7 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to any of the following people:
-
-* Harel Mazor (harel.mazor AT gmail DOT com)
-* Birk Skyum (birk.skyum AT pm DOT me)
-* Oliver Wipfli (oliver.wipfli.f AT gmail DOT com)
+reported to any Governing Board member. For contact details, see https://maplibre.org/about.
 
 All complaints will be reviewed and investigated promptly and fairly.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -63,9 +63,9 @@ representative at an online or offline event.
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to any of the following people:
 
-- Harel Mazor (harel.mazor AT gmail DOT com)
-- Birk Skyum (birk.skyum AT pm DOT me)
-- Oliver Wipfli (oliver.wipfli.f AT gmail DOT com)
+* Harel Mazor (harel.mazor AT gmail DOT com)
+* Birk Skyum (birk.skyum AT pm DOT me)
+* Oliver Wipfli (oliver.wipfli.f AT gmail DOT com)
 
 All complaints will be reviewed and investigated promptly and fairly.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,13 +60,15 @@ representative at an online or offline event.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-[code-of-conduct@maplibre.org](mailto:code-of-conduct@maplibre.org).
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to any of the following people:
+
+- Harel Mazor (harel.mazor AT gmail DOT com)
+- Birk Skyum (birk.skyum AT pm DOT me)
+- Oliver Wipfli (oliver.wipfli.f AT gmail DOT com)
+
 All complaints will be reviewed and investigated promptly and fairly.
 
-All community leaders are obligated to respect the privacy and security of the
-reporter of any incident.
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 
 ## Enforcement Guidelines
 


### PR DESCRIPTION
This PR replaces the anonymous e-mail address with personal e-mail addresses.

This makes it safer to send a report.

Thanks goes to Nuxt for the idea.