### PR TITLE
Add intellectual property violation policy

### DIFF
--- a/INTELLECTUAL_PROPERTY_VIOLATION_POLICY.md
+++ b/INTELLECTUAL_PROPERTY_VIOLATION_POLICY.md
@@ -1,0 +1,20 @@
+# Intellectual Property Violation Policy
+
+This intellectual property violation policy outlines how the MapLibre Organization plans to react in case a person should commit a copyright infringement.
+
+## Definitions
+
+**Violator**: A person who violated intellectual property rights by committing illegally copied code to the MapLibre codebase.
+
+## Steps
+
+Should we detect a copyright infringement, our reaction will be the following:
+
+* Contact Open Source Collective, MapLibre's fiscal host, and inform them that illegally copied code was detected in the MapLibre codebase.
+* Contact the owner of the intellectual property and inform them that illegally copied code was detected in the MapLibre codebase.
+* Contact the violator and inform them of the consequences of their action.
+* The action against the violator shall be to do the following for up to 3 months in case of a first infringement and up to 2 years in case of repeated infringement:
+  * Block the violator from any interaction with the MapLibre community on GitHub, i.e. they are not allowed to open or participate in any pull requests, issues, or discussions.
+  * Block the violator from participating in the Technical Steering Committee meetings.
+* Make a public statement that illegally copied code was detected in the MapLibre codebase and communicate what the next steps will be, link to this policy.
+* Start a public and transparent process of how we plan to remove the illegally copied code from the MapLibre codebase and inform all involved parties on a regular basis about the progress.


### PR DESCRIPTION
This pull request adds an intellectual property violation policy that has been approved by the MapLibre Governing Board.

The goal of this policy is to be prepared should we ever encounter that someone copied code into our codebases and violated intellectual property rights of third parties.

Note that this is not in reaction to a past event, but more as a general precaution for possible negative events in the future which we hope will never take place.