### PR TITLE
Remove Supported tier

### DIFF
--- a/PROJECT_TIERS.md
+++ b/PROJECT_TIERS.md
@@ -2,7 +2,7 @@
 
 The MapLibre Organization maintains the map rendering frameworks MapLibre GL JS and MapLibre GL Native and fosters an ecosystem of plugins and tools around these libraries to produce the best maps in the world.
 
-The two project tiers Core and Hosted describe qualitatively how organization resources are distributed among the projects.
+The project tiers Core and Hosted describe qualitatively how organization resources are distributed among the projects.
 
 ## Tiers
 

--- a/PROJECT_TIERS.md
+++ b/PROJECT_TIERS.md
@@ -27,7 +27,6 @@ Changing the tier of a project requires approval by the MapLibre Governing Board
 ### Core
 
 * [maplibre-gl-js](https://github.com/maplibre/maplibre-gl-js)
-* [maplibre-gl-js-docs](https://github.com/maplibre/maplibre-gl-js-docs)
 * [maplibre-native](https://github.com/maplibre/maplibre-native)
 * [maplibre-native-base](https://github.com/maplibre/maplibre-native-base)
 * [maplibre-plugins-android](https://github.com/maplibre/maplibre-plugins-android)

--- a/PROJECT_TIERS.md
+++ b/PROJECT_TIERS.md
@@ -2,17 +2,13 @@
 
 The MapLibre Organization maintains the map rendering frameworks MapLibre GL JS and MapLibre GL Native and fosters an ecosystem of plugins and tools around these libraries to produce the best maps in the world.
 
-The three project tiers Core, Supported, and Hosted describe qualitatively how organization resources are distributed among the projects.
+The two project tiers Core and Hosted describe qualitatively how organization resources are distributed among the projects.
 
 ## Tiers
 
 ### Core Project
 
 A project that the MapLibre Organization is committed to long-term. A substantial amount of resources is allocated to the project in the form of paid Maintainer time and paid Bounties to ensure its long-term success.
-
-### Supported Project
-
-A project that the MapLibre Organization can allocate resources to in the form of paid Bounties. Supported Projects receive a substantially smaller amount of resources than Core Projects and the MapLibre Organization does not guarantee any level of long-term support.
 
 ### Hosted Project
 
@@ -41,10 +37,6 @@ Changing the tier of a project requires approval by the MapLibre Governing Board
 * [maplibre-gl-native-distribution](https://github.com/maplibre/maplibre-gl-native-distribution)
 * [maplibre-style-spec](https://github.com/maplibre/maplibre-style-spec)
 
-### Supported
-
-* [maplibre-rs](https://github.com/maplibre/maplibre-rs)
-
 ### Hosted
 
-* All projects in the [MapLibre GitHub organization](https://github.com/maplibre/) which are not in the Core or Supported tier.
+* All projects in the [MapLibre GitHub organization](https://github.com/maplibre/) which are not in the Core tier.


### PR DESCRIPTION
This PR removes the supported tier in favor of Core (sponsored) and Hosted (not sponsored).

The Supported tier has in practice been equal to the Hosted tier, since it's too vaguely defined where the line is drawn between a Core (sponsored) and Supported (*partially sponsored) project.

There's effectively only one difference between the two, which is that an unspecified "Smaller" amount of bounties are allowed in a Sponsored project. Unfortunately, since funds for staff to manage such a system isn't allowed in that tier it's infeasible to implement, thus effectively equating Sponsored and Hosted tiers.