### PR TITLE
Add process and pull request template for nominating voting members

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,4 @@
+Click the `Preview` tab and select a PR template:
+
+- [Empty](?expand=1&template=empty.md)
+- [Nomination for a voting member](?expand=1&template=voting_member_nomination.md&labels=voting-member-nomination)

--- a/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
 Click the `Preview` tab and select a PR template:
 
 - [Empty](?expand=1&template=empty.md)
-- [Nomination for a voting member](?expand=1&template=voting_member_nomination.md&labels=voting-member-nomination)
+- [Nomination for a Voting Member](?expand=1&template=voting_member_nomination.md&labels=voting-member-nomination)

--- a/.github/PULL_REQUEST_TEMPLATE/voting_member_nomination.md
+++ b/.github/PULL_REQUEST_TEMPLATE/voting_member_nomination.md
@@ -2,16 +2,16 @@ I would like to nominate @github_handle_here to become a MapLibre Voting Member.
 
 ## Motivation
 
-<!-- Explain here why you believe @github_handle_here should be a voting member. -->
+<!-- Explain here why you believe @github_handle_here should be a Voting Member. -->
 
 ## Checklist
 
 - [ ] The nominee contributed in a non-trivial way or donated funds to the MapLibre Organization.
 - [ ] This PR updates `VOTING_MEMBERS.md` with the GitHub handle and current employer (when applicable) of the nominee.
-- [ ] The nominee has approved the pull request to indicate they want to be a voting member of MapLibre.
+- [ ] The nominee has approved the pull request to indicate they want to be a Voting Member of MapLibre.
 - [ ] The nominee has shared their full name and contact e-mail with [Hubspot link].
-- [ ] At the voting deadline[^1], more voting members have approved this pull request than disapproved this pull request.
+- [ ] At the voting deadline[^1], more Voting Members have approved this pull request than disapproved this pull request.
 
-More details on the process of nominating voting members can be found [here](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md#process).
+More details on the process of nominating Voting Members can be found [here](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md#process).
 
 [^1]: Thursday, Aug 22nd, 2024 at 17:00 CEST

--- a/.github/PULL_REQUEST_TEMPLATE/voting_member_nomination.md
+++ b/.github/PULL_REQUEST_TEMPLATE/voting_member_nomination.md
@@ -12,6 +12,6 @@ I would like to nominate @github_handle_here to become a MapLibre Voting Member.
 - [ ] The nominee has shared their full name and contact e-mail with [Hubspot link].
 - [ ] At the voting deadline[^1], more voting members have approved this pull request than disapproved this pull request.
 
-More details on the process of nominating voting members can be found [here].
+More details on the process of nominating voting members can be found [here](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md#process).
 
 [^1]: Thursday, Aug 22nd, 2024 at 17:00 CEST

--- a/.github/PULL_REQUEST_TEMPLATE/voting_member_nomination.md
+++ b/.github/PULL_REQUEST_TEMPLATE/voting_member_nomination.md
@@ -1,0 +1,17 @@
+I would like to nominate @github_handle_here to become a MapLibre Voting Member.
+
+## Motivation
+
+<!-- Explain here why you believe @github_handle_here should be a voting member. -->
+
+## Checklist
+
+- [ ] The nominee contributed in a non-trivial way or donated funds to the MapLibre Organization.
+- [ ] This PR updates `VOTING_MEMBERS.md` with the GitHub handle and current employer (when applicable) of the nominee.
+- [ ] The nominee has approved the pull request to indicate they want to be a voting member of MapLibre.
+- [ ] The nominee has shared their full name and contact e-mail with [Hubspot link].
+- [ ] At the voting deadline[^1], more voting members have approved this pull request than disapproved this pull request.
+
+More details on the process of nominating voting members can be found [here].
+
+[^1]: Thursday, Aug 22nd, 2024 at 17:00 CEST

--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -1,6 +1,32 @@
 # MapLibre Voting Members
 
-This file lists all MapLibre Voting Members. See the [Charter](https://github.com/maplibre/maplibre/blob/main/CHARTER.md) for more information about the competency of the MapLibre Voting Members.
+This file lists all MapLibre Voting Members. The [MapLibre Charter](https://maplibre.org/charter/) is the official source of information about the competency of the MapLibre Voting Members.
+
+## Process
+
+### I am a Voting Member
+
+If you are a [MapLibre Voting Member](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md), you can vote on granting Voting Membership by approving or disapproving [nominations for voting members](https://github.com/maplibre/maplibre/labels/voting-member-nomination). Approve PRs to show your support for the person or reject PRs to indicate that you disagree with granting Voting Membership.
+
+Voting is open until Thursday, Aug 22nd, 2024 at 17:00 CEST.
+
+### I am nominated
+
+If you have been nominated in a Pull Request to become a Voting Member, then you have two choices:
+
+- You say YES, I want to be a Voting Member. In this case, please:
+  - Approve this pull request.
+  - We need your email for the online voting system OpaVote which is used for the Governing Board election. Send us your email address via the following form: LINK. 
+- You say NO, I don't want to be a Voting Member. In this case, please
+  - Comment below "Please close this pull request, I don't want to be a Voting Member".
+
+### I would like to nominate someone
+
+If you are a [MapLibre Voting Member](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md#list-of-voting-members), you can nominate someone by opening a pull request that adds their GitHub handle and choosing the [`voting_member_nomination.md`](https://github.com/maplibre/maplibre/blob/main/.github/PULL_REQUEST_TEMPLATE/voting_member_nomination.md) pull request template.
+
+### I would like to be nominated
+
+If you are not a Voting Member but would like to become one, find someone who is on the voting member list (see below) and ask them if they can nominate you.
 
 ## List of Voting Members
 

--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -6,7 +6,7 @@ This file lists all MapLibre Voting Members. The [MapLibre Charter](https://mapl
 
 ### I am a Voting Member
 
-If you are a [MapLibre Voting Member](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md), you can vote on granting Voting Membership by approving or disapproving [nominations for voting members](https://github.com/maplibre/maplibre/labels/voting-member-nomination). Approve PRs to show your support for the person or reject PRs to indicate that you disagree with granting Voting Membership.
+If you are a [MapLibre Voting Member](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md), you can vote on granting Voting Membership by approving or disapproving [nominations for Voting Members](https://github.com/maplibre/maplibre/labels/voting-member-nomination). Approve PRs to show your support for the person or reject PRs to indicate that you disagree with granting Voting Membership.
 
 Voting is open until Thursday, Aug 22nd, 2024 at 17:00 CEST.
 

--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -15,10 +15,10 @@ Voting is open until Thursday, Aug 22nd, 2024 at 17:00 CEST.
 If you have been nominated in a Pull Request to become a Voting Member, then you have two choices:
 
 - You say YES, I want to be a Voting Member. In this case, please:
-  - Approve this pull request.
-  - We need your email for the online voting system OpaVote which is used for the Governing Board election. Send us your email address via the following form: LINK. 
+  - Approve the pull request.
+  - We need your email for the online voting system OpaVote which is used for the Governing Board election. Send us your email address via the following form: LINK.
 - You say NO, I don't want to be a Voting Member. In this case, please
-  - Comment below "Please close this pull request, I don't want to be a Voting Member".
+  - Leave a comment indicating that you don't want to be a Voting Member. The pull request will be closed.
 
 ### I would like to nominate someone
 
@@ -26,7 +26,7 @@ If you are a [MapLibre Voting Member](https://github.com/maplibre/maplibre/blob/
 
 ### I would like to be nominated
 
-If you are not a Voting Member but would like to become one, find someone who is on the voting member list (see below) and ask them if they can nominate you.
+If you are not a Voting Member but would like to become one, find someone who is on the Voting Member list (see below) and ask them if they can nominate you.
 
 ## List of Voting Members
 


### PR DESCRIPTION
Based on  https://github.com/wipfli/maplibre/pull/1 

- This adds a pull request template for creating a nomination for a voting members, so people can select this template when making a pull request, so they don't need to copy paste the template by hand.
- Explanation of the process written by @wipfli is added to `VOTING_MEMBERS.md`.
- I created a new label `voting-member-nomination` which is added by the template link so people have an overview of all nominations and can vote on the ones they want.

Draft pull request, the HubSpot link needs to be added in two places.