### PR TITLE
Nominate Patrick Wolowicz (@hactar) as MapLibre Voting Member

### DIFF
--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -44,6 +44,8 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@fynngodau](https://github.com/fynngodau)
 
+[@hactar](https://github.com/hactar) (self-employed, MapLibre using clients include Bikemap, HudHud Maps and the City of Vienna)
+
 [@HarelM](https://github.com/harelm)
 
 [@HandyMenny](https://github.com/HandyMenny)


### PR DESCRIPTION
I would like to nominate Patrick Wolowicz - @hactar to become a MapLibre Voting Member.

## Motivation

Active reviewing of current PRs. Involvement in Slack, SPM and sheet-less version of MapLibre Navigation, and the prototype for MapLibre DSL for SwiftUI (https://github.com/stadiamaps/maplibre-swiftui-dsl-playground). 

## Checklist

- [X] The nominee contributed in a non-trivial way or donated funds to the MapLibre Organization.
- [X] This PR updates `VOTING_MEMBERS.md` with the GitHub handle and current employer (when applicable) of the nominee.
- [X] The nominee has approved the pull request to indicate they want to be a Voting Member of MapLibre.
- [x] The nominee has shared their full name and contact e-mail with [this form](https://share-eu1.hsforms.com/1OcrNFreTRMqPRb0_PlOt3gfn2ab).
- [ ] At the voting deadline[^1], more [Voting Members](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md) have approved this pull request than disapproved this pull request.

More details on the process of nominating Voting Members can be found [here](https://github.com/maplibre/maplibre/issues/376).

[^1]: Thursday, Aug 22nd, 2024 at 17:00 CEST
