### PR TITLE
Nominate Ryan Gartin (@nitrag)

### DIFF
--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -108,6 +108,8 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@mwilsnd](https://github.com/mwilsnd) (Meta)
 
+[@nitrag](https://github.com/nitrag)
+
 [@ntadej](https://github.com/ntadej)
 
 [@nreese](https://github.com/nreese) (Elastic)


### PR DESCRIPTION
I would like to nominate @nitrag to become a MapLibre Voting Member.

## Motivation

Contributions to navigation

## Checklist

- [x] The nominee contributed in a non-trivial way or donated funds to the MapLibre Organization.
- [x] This PR updates `VOTING_MEMBERS.md` with the GitHub handle and current employer (when applicable) of the nominee.
- [ ] The nominee has approved the pull request to indicate they want to be a Voting Member of MapLibre.
- [ ] The nominee has shared their full name and contact e-mail with [this form](https://share-eu1.hsforms.com/1OcrNFreTRMqPRb0_PlOt3gfn2ab).
- [ ] At the voting deadline[^1], more [Voting Members](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md) have approved this pull request than disapproved this pull request.

More details on the process of nominating Voting Members can be found [here](https://github.com/maplibre/maplibre/issues/376).

[^1]: Thursday, Aug 22nd, 2024 at 17:00 CEST
