### PR TITLE
Nominate Alex Cristici as Voting Member

### DIFF
--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -10,6 +10,8 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@alanchenboy](https://github.com/alanchenboy) (Grab Technology (Beijing) Co., Ltd.)
 
+[@alexcristici](https://github.com/alexcristici)
+
 [@ambientlight](https://github.com/ambientlight) (Microsoft)
 
 [@atierian](https://github.com/atierian) (AWS)

--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -10,7 +10,7 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@alanchenboy](https://github.com/alanchenboy) (Grab Technology (Beijing) Co., Ltd.)
 
-[@alexcristici](https://github.com/alexcristici)
+[@alexcristici](https://github.com/alexcristici) (AWS)
 
 [@ambientlight](https://github.com/ambientlight) (Microsoft)
 


### PR DESCRIPTION
I would like to nominate @alexcristici to become a MapLibre Voting Member.

## Motivation

<!-- Explain here why you believe your nominee should be a Voting Member. -->

It is hard to overstate the impact of Alex' work on MapLibre Native. He was instrumental for the modularization of the renderer and the Metal backend. He also worked on the benchmarks on both iOS and Android, which have been used for performance optimizations.

## Checklist

- [x] The nominee contributed in a non-trivial way or donated funds to the MapLibre Organization.
- [x] This PR updates `VOTING_MEMBERS.md` with the GitHub handle and current employer (when applicable) of the nominee.
- [x] The nominee has approved the pull request to indicate they want to be a Voting Member of MapLibre.
- [x] The nominee has shared their full name and contact e-mail with [this form](https://share-eu1.hsforms.com/1OcrNFreTRMqPRb0_PlOt3gfn2ab).
- [ ] At the voting deadline[^1], more [Voting Members](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md) have approved this pull request than disapproved this pull request.

More details on the process of nominating Voting Members can be found [here](https://github.com/maplibre/maplibre/issues/376).

[^1]: Thursday, Aug 22nd, 2024 at 17:00 CEST
