### PR TITLE
nominate keichan34 as voting member

### DIFF
--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -76,6 +76,8 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@Kanahiro](https://github.com/Kanahiro) (Mierune)
 
+[@keichan34](https://github.com/keichan34)
+
 [@kevinschaul](https://github.com/kevinschaul)
 
 [@klokan](https://github.com/klokan) (MapTiler)


### PR DESCRIPTION
I would like to nominate @keichan34 to become a MapLibre Voting Member.

## Motivation

Participation in Maputnik project, e.g. https://github.com/maplibre/maputnik/pull/917

## Checklist

- [x] The nominee contributed in a non-trivial way or donated funds to the MapLibre Organization.
- [x] This PR updates `VOTING_MEMBERS.md` with the GitHub handle and current employer (when applicable) of the nominee.
- [x] The nominee has approved the pull request to indicate they want to be a Voting Member of MapLibre.
- [x] The nominee has shared their full name and contact e-mail with [this form](https://share-eu1.hsforms.com/1OcrNFreTRMqPRb0_PlOt3gfn2ab).
- [ ] At the voting deadline[^1], more [Voting Members](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md) have approved this pull request than disapproved this pull request.

More details on the process of nominating Voting Members can be found [here](https://github.com/maplibre/maplibre/issues/376).

[^1]: Thursday, Aug 22nd, 2024 at 17:00 CEST
