### PR TITLE
Nominate Eric Brelsford and Dane Springmeyer to voting members

### DIFF
--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -38,6 +38,8 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@duje](https://github.com/duje)
 
+[@ebrelsford](https://github.com/ebrelsford)
+
 [@Fabi755](https://github.com/Fabi755)
 
 [@fredj](https://github.com/fredj) (Camptocamp)
@@ -151,6 +153,8 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 [@sjoerdperfors](https://github.com/sjoerdperfors) (Flitsmeister)
 
 [@smellyshovel](https://github.com/smellyshovel)
+
+[@springmeyer](https://github.com/springmeyer)
 
 [@stefanschaller](https://github.com/stefanschaller) (tapped.dev)
 

--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -154,7 +154,7 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@smellyshovel](https://github.com/smellyshovel)
 
-[@springmeyer](https://github.com/springmeyer)
+[@springmeyer](https://github.com/springmeyer) (Dane Springmeyer LLC)
 
 [@stefanschaller](https://github.com/stefanschaller) (tapped.dev)
 

--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -38,7 +38,7 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@duje](https://github.com/duje)
 
-[@ebrelsford](https://github.com/ebrelsford)
+[@ebrelsford](https://github.com/ebrelsford) (Stamen)
 
 [@Fabi755](https://github.com/Fabi755)
 


### PR DESCRIPTION
I would like to nominate @ebrelsford and @springmeyer to become MapLibre Voting Members.

## Motivation

Their work on `maplibre-tile-spec`:
* https://github.com/search?q=repo%3Amaplibre%2Fmaplibre-tile-spec+author%3Aebrelsford&type=pullrequests
* https://github.com/search?q=repo%3Amaplibre%2Fmaplibre-tile-spec+author%3Aspringmeyer&type=pullrequests

## Checklist

- [x] The nominee contributed in a non-trivial way or donated funds to the MapLibre Organization.
- [x] This PR updates `VOTING_MEMBERS.md` with the GitHub handle and current employer (when applicable) of the nominee.
- [ ] ~~The nominee has approved the pull request to indicate they want to be a Voting Member of MapLibre.~~
- [ ] ~~The nominee has shared their full name and contact e-mail with [this form](https://share-eu1.hsforms.com/1OcrNFreTRMqPRb0_PlOt3gfn2ab).~~
- [ ] At the voting deadline[^1], more [Voting Members](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md) have approved this pull request than disapproved this pull request.

## Nominees
- [x] @ebrelsford approved Pull Request and shared email via form
- [x] @springmeyer approve Pull Request and shared email via form

More details on the process of nominating Voting Members can be found [here](https://github.com/maplibre/maplibre/issues/376).

[^1]: Thursday, Aug 22nd, 2024 at 17:00 CEST
