### PR TITLE
Nominate tomeronen as a voting member

### DIFF
--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -168,6 +168,8 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@tjulien](https://github.com/tjulien) (Radar Labs, Inc.)
 
+[@tomeronen](https://github.com/tomeronen)
+
 [@tompohys](https://github.com/TomPohys) (MapTiler)
 
 [@tordans](https://github.com/tordans) (FixMyCity GmbH)


### PR DESCRIPTION
I would like to nominate @tomeronen to become a MapLibre Voting Member.

## Motivation

Significant UI work in Martin: https://github.com/search?q=org%3Amaplibre+author%3Atomeronen&type=pullrequests

Note that the PRs were not merged, as their content is being adapted as part of others, but there was significant efforts put into them for sure (thanks!)

## Checklist

- [x] The nominee contributed in a non-trivial way or donated funds to the MapLibre Organization.
- [x] This PR updates `VOTING_MEMBERS.md` with the GitHub handle and current employer (when applicable) of the nominee.
- [x] The nominee has approved the pull request to indicate they want to be a Voting Member of MapLibre.
- [x] The nominee has shared their full name and contact e-mail with [this form](https://share-eu1.hsforms.com/1OcrNFreTRMqPRb0_PlOt3gfn2ab).
- [ ] At the voting deadline[^1], more [Voting Members](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md) have approved this pull request than disapproved this pull request.

More details on the process of nominating Voting Members can be found [here](https://github.com/maplibre/maplibre/issues/376).

[^1]: Thursday, Aug 22nd, 2024 at 17:00 CEST
