### PR TITLE
Nominate  tyrauber as Voting Member

### DIFF
--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -176,6 +176,8 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@typebrook](https://github.com/typebrook)
 
+[@tyrauber](https://github.com/tyrauber)
+
 [@upsicleclown](https://github.com/upsicleclown)
 
 [@VehpuS](https://github.com/VehpuS) (Nucleai)


### PR DESCRIPTION
I would like to nominate @tyrauber to become a MapLibre Voting Member.

## Motivation

Ty is the lead maintainer of [maplibre-react-native](https://github.com/maplibre/maplibre-react-native).

Thank you for all your contributions, Ty!

## Checklist

- [x] The nominee contributed in a non-trivial way or donated funds to the MapLibre Organization.
- [x] This PR updates `VOTING_MEMBERS.md` with the GitHub handle and current employer (when applicable) of the nominee.
- [x] The nominee has approved the pull request to indicate they want to be a Voting Member of MapLibre.
- [x] The nominee has shared their full name and contact e-mail with [this form](https://share-eu1.hsforms.com/1OcrNFreTRMqPRb0_PlOt3gfn2ab).
- [ ] At the voting deadline[^1], more [Voting Members](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md) have approved this pull request than disapproved this pull request.

More details on the process of nominating Voting Members can be found [here](https://github.com/maplibre/maplibre/issues/376).

[^1]: Thursday, Aug 22nd, 2024 at 17:00 CEST
