### PR TITLE
Nominate Jacob Fielding as a voting member

### DIFF
--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -12,6 +12,8 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@ambientlight](https://github.com/ambientlight) (Microsoft)
 
+[@archdoog](https://github.com/archdoog) (Rallista)
+
 [@atierian](https://github.com/atierian) (AWS)
 
 [@bchapuis](https://github.com/bchapuis)


### PR DESCRIPTION
I would like to nominate @archdoog to become a MapLibre Voting Member.

## Motivation

Jacob has been a long-time user of MapLibre Native and has made extensive contributions to numerous projects in the ecosystem over the past year:

* He is a core contributor to the SwiftUI DSL for MapLibre Native ([recently approved for onboarding to MapLibre proper after significant development](https://github.com/maplibre/maplibre/issues/371))
* He is leading the development of a [similar declarative UI project](https://github.com/Rallista/maplibre-compose-playground) for Jetpack Compose on Android
* He has reviewed PRs for the MapLibre Navigation and MapLibre Native projects
* He is a core contributor to Ferrostar, a project that is helping to shape the future of turn-by-turn navigation with MapLibre on mobile, web, and other platforms
* He helped get the MapLibre Navigation meeting series going, and is a regular participant

## Checklist

- [x] The nominee contributed in a non-trivial way or donated funds to the MapLibre Organization.
- [x] This PR updates `VOTING_MEMBERS.md` with the GitHub handle and current employer (when applicable) of the nominee.
- [x] The nominee has approved the pull request to indicate they want to be a Voting Member of MapLibre.
- [x] The nominee has shared their full name and contact e-mail with [this form](https://share-eu1.hsforms.com/1OcrNFreTRMqPRb0_PlOt3gfn2ab).
- [ ] At the voting deadline[^1], more [Voting Members](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md) have approved this pull request than disapproved this pull request.

More details on the process of nominating Voting Members can be found [here](https://github.com/maplibre/maplibre/issues/376).

[^1]: Thursday, Aug 22nd, 2024 at 17:00 CEST
