### PR TITLE
Nominate Keith Smiley as Voting Member

### DIFF
--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -76,7 +76,7 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@Kanahiro](https://github.com/Kanahiro) (Mierune)
 
-[@keith](https://github.com/keith) (Lyft)
+[@keith](https://github.com/keith) (Modular)
 
 [@kevinschaul](https://github.com/kevinschaul)
 

--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -76,6 +76,8 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@Kanahiro](https://github.com/Kanahiro) (Mierune)
 
+[@keith](https://github.com/keith) (Lyft)
+
 [@kevinschaul](https://github.com/kevinschaul)
 
 [@klokan](https://github.com/klokan) (MapTiler)


### PR DESCRIPTION
I would like to nominate @keith to become a MapLibre Voting Member.

## Motivation

<!-- Explain here why you believe your nominee should be a Voting Member. -->

Keith made a significant contribution to MapLibre Native through his role as the maintainer of Bazel's iOS support, which we rely on with great succes. Aside from that Keith also made some contributions to modernize our Bazel config: https://github.com/maplibre/maplibre-native/pulls?q=is%3Apr+author%3Akeith+is%3Aclosed

## Checklist

- [x] The nominee contributed in a non-trivial way or donated funds to the MapLibre Organization.
- [x] This PR updates `VOTING_MEMBERS.md` with the GitHub handle and current employer (when applicable) of the nominee.
- [ ] The nominee has approved the pull request to indicate they want to be a Voting Member of MapLibre.
- [ ] The nominee has shared their full name and contact e-mail with [this form](https://share-eu1.hsforms.com/1OcrNFreTRMqPRb0_PlOt3gfn2ab).
- [ ] At the voting deadline[^1], more [Voting Members](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md) have approved this pull request than disapproved this pull request.

More details on the process of nominating Voting Members can be found [here](https://github.com/maplibre/maplibre/issues/376).

[^1]: Thursday, Aug 22nd, 2024 at 17:00 CEST
