### PR TITLE
Nominate Igal Fleishman as Voting Member

### DIFF
--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -56,6 +56,8 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@ibesora](https://github.com/ibesora) (Felt)
 
+[@igal1c0de4n](https://github.com/igal1c0de4n) (mapme)
+
 [@IvanSanchez](https://github.com/IvanSanchez)
 
 [@JannikGM](https://github.com/JannikGM) (Graphmasters GmbH)

--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -56,7 +56,7 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@ibesora](https://github.com/ibesora) (Felt)
 
-[@igal1c0de4n](https://github.com/igal1c0de4n) (mapme)
+[@igal1c0de4n](https://github.com/igal1c0de4n) (Mapme)
 
 [@IvanSanchez](https://github.com/IvanSanchez)
 


### PR DESCRIPTION
I would like to nominate @igal1c0de4n to become a MapLibre Voting Member.

## Motivation

Igal is the CTO of mapme, our latest [Silver Sponsor](https://maplibre.org/news/2024-06-28-mapme-announcement/)!

## Checklist

- [x] The nominee contributed in a non-trivial way or donated funds to the MapLibre Organization.
- [x] This PR updates `VOTING_MEMBERS.md` with the GitHub handle and current employer (when applicable) of the nominee.
- [x] The nominee has approved the pull request to indicate they want to be a Voting Member of MapLibre.
- [x] The nominee has shared their full name and contact e-mail with [this form](https://share-eu1.hsforms.com/1OcrNFreTRMqPRb0_PlOt3gfn2ab).
- [ ] At the voting deadline[^1], more [Voting Members](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md) have approved this pull request than disapproved this pull request.

More details on the process of nominating Voting Members can be found [here](https://github.com/maplibre/maplibre/issues/376).

[^1]: Thursday, Aug 22nd, 2024 at 17:00 CEST
