### PR TITLE
Remove @metaceo from Voting Members

### DIFF
--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -128,8 +128,6 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@maxammann](https://github.com/maxammann)
 
-[@metaceo](https://github.com/metaceo)
-
 [@michaelkirk](https://github.com/michaelkirk)
 
 [@Miguel-Sanches](https://github.com/Miguel-Sanches) (one.network)


### PR DESCRIPTION
I propose to remove @METACEO from the list of Voting Members. We never had the email address of @METACEO so they never participated in an election and we did not find a way to contact them.

Alternatively, we can leave @METACEO in the list of Voting Members but add a comment like "Inactive - no contact available".