### PR TITLE
Remove @nvanfleet from Voting Members

### DIFF
--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -152,8 +152,6 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@neodescis](https://github.com/neodescis)
 
-[@nvanfleet](https://github.com/nvanfleet)
-
 [@nyurik](https://github.com/nyurik) (Rivian)
 
 [@olsen232](https://github.com/olsen232)


### PR DESCRIPTION
@nvanfleet opted out from the OpaVote poll. I asked him by email if I should remove him as well from the list of Voting Members such that he does not get any emails anymore in the coming years and he said yes...

- [ ] Merge Pull Request
- [ ] Remove in HubSpot