### PR TITLE
Add Supported tier

### DIFF
--- a/PROJECT_TIERS.md
+++ b/PROJECT_TIERS.md
@@ -30,35 +30,38 @@ Changing the tier of a project requires approval by the MapLibre Governing Board
 
 ### Core
 
-* [maplibre-gl-js](https://github.com/maplibre/maplibre-gl-js)
-* [maplibre-native](https://github.com/maplibre/maplibre-native)
-* [maplibre-style-spec](https://github.com/maplibre/maplibre-style-spec)
+- [maplibre-gl-js](https://github.com/maplibre/maplibre-gl-js)
+- [maplibre-native](https://github.com/maplibre/maplibre-native)
+- [maplibre-style-spec](https://github.com/maplibre/maplibre-style-spec)
 
 ### Supported
 
-* [maplibre-tile-spec](https://github.com/maplibre/maplibre-tile-spec)
-* [maputnik](https://github.com/maplibre/maputnik)
-* [martin](https://github.com/maplibre/martin)
+- [maplibre-tile-spec](https://github.com/maplibre/maplibre-tile-spec)
+- [maputnik](https://github.com/maplibre/maputnik)
+- [martin](https://github.com/maplibre/martin)
 
 MapLibre GL JS dependencies
-* [vtvalidate](https://github.com/maplibre/vtvalidate)
+
+- [vtvalidate](https://github.com/maplibre/vtvalidate)
 
 MapLibre Native dependencies and distribution
-* [geojson-cpp](https://github.com/maplibre/geojson-cpp)
-* [geometry.hpp](https://github.com/maplibre/geometry.hpp)
-* [maplibre-gl-native-distribution](https://github.com/maplibre/maplibre-gl-native-distribution)
-* [maplibre-java](https://github.com/maplibre/maplibre-java)
-* [maplibre-plugins-android](https://github.com/maplibre/maplibre-plugins-android)
-  * [Annotations](https://github.com/maplibre/maplibre-plugins-android/tree/main/plugin-annotation): Supported
-  * Other plugins: Hosted
-* [mvt-cpp](https://github.com/maplibre/mvt-cpp)
+
+- [geojson-cpp](https://github.com/maplibre/geojson-cpp)
+- [geometry.hpp](https://github.com/maplibre/geometry.hpp)
+- [maplibre-gl-native-distribution](https://github.com/maplibre/maplibre-gl-native-distribution)
+- [maplibre-java](https://github.com/maplibre/maplibre-java)
+- [maplibre-plugins-android](https://github.com/maplibre/maplibre-plugins-android)
+  - [Annotations](https://github.com/maplibre/maplibre-plugins-android/tree/main/plugin-annotation): Supported
+  - Other plugins: Hosted
+- [mvt-cpp](https://github.com/maplibre/mvt-cpp)
 
 MapLibre Native SDKs
-* [flutter-maplibre-gl](https://github.com/maplibre/flutter-maplibre-gl)
-* [maplibre-compose](https://github.com/maplibre/maplibre-compose)
-* [maplibre-react-native](https://github.com/maplibre/maplibre-react-native)
-* [maplibre-native-qt](https://github.com/maplibre/maplibre-native-qt)
+
+- [flutter-maplibre-gl](https://github.com/maplibre/flutter-maplibre-gl)
+- [maplibre-compose](https://github.com/maplibre/maplibre-compose)
+- [maplibre-react-native](https://github.com/maplibre/maplibre-react-native)
+- [maplibre-native-qt](https://github.com/maplibre/maplibre-native-qt)
 
 ### Hosted
 
-* All projects in the [MapLibre GitHub organization](https://github.com/maplibre/) which are not in the Core or Supported tier.
+- All projects in the [MapLibre GitHub organization](https://github.com/maplibre/) which are not in the Core or Supported tier.


### PR DESCRIPTION
We have some projects that occasions need a limited investment to stay healthy.

They don't fit well in the Core nor the Hosted tier.

Therefore this PR adds a Supported tier to give this level of flexibility.

Projects of strategic value to populate this category initially are:
- maputnik
- maplibre-tile-spec
- martin
- Deps of GL JS
- Deps of Native
- SDKs for Native
