### PR TITLE
Add maplibre-tile-spec to Core Projects

### DIFF
--- a/PROJECT_TIERS.md
+++ b/PROJECT_TIERS.md
@@ -27,15 +27,16 @@ Changing the tier of a project requires approval by the MapLibre Governing Board
 ### Core
 
 * [maplibre-gl-js](https://github.com/maplibre/maplibre-gl-js)
-* [maplibre-native](https://github.com/maplibre/maplibre-native)
+* [maplibre-gl-native-distribution](https://github.com/maplibre/maplibre-gl-native-distribution)
+* [maplibre-java](https://github.com/maplibre/maplibre-java)
 * [maplibre-native-base](https://github.com/maplibre/maplibre-native-base)
+* [maplibre-native](https://github.com/maplibre/maplibre-native)
 * [maplibre-plugins-android](https://github.com/maplibre/maplibre-plugins-android)
   * [Annotations](https://github.com/maplibre/maplibre-plugins-android/tree/main/plugin-annotation): Core
   * Other plugins: Hosted
-* [mvt-cpp](https://github.com/maplibre/mvt-cpp)
-* [maplibre-java](https://github.com/maplibre/maplibre-java)
-* [maplibre-gl-native-distribution](https://github.com/maplibre/maplibre-gl-native-distribution)
 * [maplibre-style-spec](https://github.com/maplibre/maplibre-style-spec)
+* [maplibre-tile-spec](https://github.com/maplibre/maplibre-tile-spec)
+* [mvt-cpp](https://github.com/maplibre/mvt-cpp)
 
 ### Hosted
 


### PR DESCRIPTION
I am doing some work to assist MapLibre Tiles implementation for MapLibre Native.

I think it makes sense to elevate this project to a core project, since it will be an important dependency of both MapLibre GL JS and MapLibre Native. We have everything in one repo right now, this is convenient so we can work together to flesh out the details of the spec and collaborate across platforms. In the future the C++/Rust/JS/Java implementations and tile generator utilities will probably be split out to their own repos.