### PR TITLE
Undo #418 until next voting member nomination

### DIFF
--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -44,8 +44,6 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@coliff](https://github.com/coliff)
 
-[@CommanderStorm](https://github.com/CommanderStorm) (Technical University of Munich)
-
 [@danielgard](https://github.com/danielgard) (komoot)
 
 [@dayjournal](https://github.com/dayjournal) (Mierune)


### PR DESCRIPTION
We should follow the official procedure for nominating and welcoming new voting members. We should undo #418 and re-open the PR when nominations open (two weeks before the board elections).

> Nominations for new Voting Members are open up to two weeks before the election of the Governing Board 

https://github.com/maplibre/maplibre/blob/main/CHARTER.md