### PR TITLE
Nominate Sargun Vohra

### DIFF
--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -182,6 +182,8 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@sarahsporck](https://github.com/sarahsporck) (Tür an Tür - Digitalfabrik gGmbH)
 
+[@sargunv](https://github.com/sargunv)
+
 [@sbachinin](https://github.com/sbachinin)
 
 [@sharkAndshark](https://github.com/sharkAndshark)


### PR DESCRIPTION
- https://github.com/maplibre/maplibre/issues/446

I'm nominating Sargun Vohra to be maplibre voting member.

### Motivation

Sargun (@sargunv) is leading the development of the new MapLibre Compose SDK for MapLibre Native. ( [maplibre-compose](https://github.com/maplibre/maplibre-compose) )