### PR TITLE
Nominate Malcolm Toon as MapLibre Voting Member

### DIFF
--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -6,6 +6,8 @@ This file lists all MapLibre Voting Members. See the [Charter](https://github.co
 
 The Voting Members, in alphabetic order by their GitHub handles, are:
 
+[@AtlasProgramming](https://github.com/AtlasProgramming)
+
 [@adrian-cojocaru](https://github.com/adrian-cojocaru) (AWS)
 
 [@acalcutt](https://github.com/acalcutt)


### PR DESCRIPTION
I would like to nominate @AtlasProgramming to become a MapLibre Voting Member.

## Motivation

<!-- Explain here why you believe your nominee should be a Voting Member. -->

Contributions to MapLibre Native, including performance improvements and the plugin layer API.

## Checklist

- [x] The nominee contributed in a non-trivial way or donated funds to the MapLibre Organization.
- [x] This PR updates `VOTING_MEMBERS.md` with the GitHub handle and current employer (when applicable) of the nominee.
- [x] The nominee has approved the pull request to indicate they want to be a Voting Member of MapLibre.
- [x] The nominee has shared their full name and contact e-mail with [this form](https://share-eu1.hsforms.com/1OcrNFreTRMqPRb0_PlOt3gfn2ab).
- [x] At the voting deadline[^1], more [Voting Members](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md) have approved this pull request than disapproved this pull request.

More details on the process of nominating Voting Members can be found [here](https://github.com/maplibre/maplibre/issues/446).

[^1]: Friday, Aug 15th, 2025 at 17:00 CEST
