### PR TITLE
Nominate Zsolt Ero as MapLibre Voting Member

### DIFF
--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -68,6 +68,8 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@HandyMenny](https://github.com/HandyMenny)
 
+[@hyperknot](https://github.com/hyperknot)
+
 [@hoeflehner](https://github.com/hoeflehner) (Maptoolkit)
 
 [@hy9be](https://github.com/hy9be) (AWS)


### PR DESCRIPTION
I would like to nominate @hyperknot to become a MapLibre Voting Member.

## Motivation

<!-- Explain here why you believe your nominee should be a Voting Member. -->

His project [OpenFreeMap](https://openfreemap.org/quick_start/) serves as an amazingly accessible way to using MapLibre. We are also using OpenFreeMap for testing purposes.

## Checklist

- [x] The nominee contributed in a non-trivial way or donated funds to the MapLibre Organization.
- [x] This PR updates `VOTING_MEMBERS.md` with the GitHub handle and current employer (when applicable) of the nominee.
- [x] The nominee has approved the pull request to indicate they want to be a Voting Member of MapLibre.
- [x] The nominee has shared their full name and contact e-mail with [this form](https://share-eu1.hsforms.com/1OcrNFreTRMqPRb0_PlOt3gfn2ab).
- [x] At the voting deadline[^1], more [Voting Members](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md) have approved this pull request than disapproved this pull request.

More details on the process of nominating Voting Members can be found [here](https://github.com/maplibre/maplibre/issues/446).

[^1]: Friday, Aug 15th, 2025 at 17:00 CEST
