### PR TITLE
Nominate Ryan Scully (wayofthefuture) as Voting Member

### DIFF
--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -240,6 +240,8 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@visitskyworld](https://github.com/visitskyworld)
 
+[@wayofthefuture](https://github.com/wayofthefuture)
+
 [@wipfli](https://github.com/wipfli)
 
 [@xabbu42](https://github.com/xabbu42) (localsearch)


### PR DESCRIPTION
I would like to nominate Ryan Scully (@wayofthefuture) to become a MapLibre Voting Member. 

## Motivation

Contributed new logo design to the Martin project. 

## Checklist

- [x] The nominee contributed in a non-trivial way or donated funds to the MapLibre Organization.
- [x] This PR updates `VOTING_MEMBERS.md` with the GitHub handle and current employer (when applicable) of the nominee.
- [x] The nominee has approved the pull request to indicate they want to be a Voting Member of MapLibre.
- [x] The nominee has shared their full name and contact e-mail with [this form](https://share-eu1.hsforms.com/1OcrNFreTRMqPRb0_PlOt3gfn2ab).
- [ ] At the voting deadline[^1], more [Voting Members](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md) have approved this pull request than disapproved this pull request.

More details on the process of nominating Voting Members can be found [here](https://github.com/maplibre/maplibre/issues/446).

[^1]: Friday, Aug 15th, 2025 at 17:00 CEST

Click the `Preview` tab and select a PR template:

- [Empty](?expand=1&template=empty.md)
- [Nomination for a Voting Member](?expand=1&template=voting_member_nomination.md&labels=voting-member-nomination)
