### PR TITLE
Nominate rshk

### DIFF
--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -180,6 +180,8 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@rotu](https://github.com/rotu)
 
+[@rshk](https://github.com/rshk)
+
 [@sarahsporck](https://github.com/sarahsporck) (Tür an Tür - Digitalfabrik gGmbH)
 
 [@sbachinin](https://github.com/sbachinin)


### PR DESCRIPTION
I would like to nominate @rshk to become a MapLibre Voting Member.

## Motivation

Added Geography support to Martin in https://github.com/maplibre/martin/pull/1627

## Checklist

- [x] The nominee contributed in a non-trivial way or donated funds to the MapLibre Organization.
- [x] This PR updates `VOTING_MEMBERS.md` with the GitHub handle and current employer (when applicable) of the nominee.
- [x] The nominee has approved the pull request to indicate they want to be a Voting Member of MapLibre.
- [x] The nominee has shared their full name and contact e-mail with [this form](https://share-eu1.hsforms.com/1OcrNFreTRMqPRb0_PlOt3gfn2ab).
- [x] At the voting deadline[^1], more [Voting Members](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md) have approved this pull request than disapproved this pull request.

More details on the process of nominating Voting Members can be found [here](https://github.com/maplibre/maplibre/issues/446).

[^1]: Friday, Aug 15th, 2025 at 17:00 CEST
