### PR TITLE
Update voting member nomination deadline to August 15, 2026

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/voting_member_nomination.md
+++ b/.github/PULL_REQUEST_TEMPLATE/voting_member_nomination.md
@@ -14,4 +14,4 @@ I would like to nominate @github_handle_here to become a MapLibre Voting Member.
 
 More details on the process of nominating Voting Members can be found [here](https://github.com/maplibre/maplibre/issues/446).
 
-[^1]: Friday, Aug 15th, 2025 at 17:00 CEST
+[^1]: Friday, Aug 15th, 2026 at 17:00 CEST


### PR DESCRIPTION
@CommanderStorm caught the fact that the charter allows nominations **up to** two weeks before the governing board elections. So nominations are possible most of the year. We should just be careful not to actually merge the PRs of those nominations until a week before the elections (after the 'vote' on the nominees).