### PR TITLE
Add AI Generated Contributions Policy

### DIFF
--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,7 +1,7 @@
 # AI Generated Contributions Policy
 
 Artificial intelligence systems raise many questions around copyright that have
-yet to be answered. As per the [GitHub TOS](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license), contributors are responsible for ensuring that they have the 
+yet to be answered. As per the [GitHub TOS](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license), contributors are responsible for ensuring that they have the
 right to contribute code under the terms of the repository license. Using AI tools to
 regenerate copyrighted material does not remove the copyright, and contributors
 are responsible for ensuring that such material does not appear in their

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,23 @@
+# AI Generated Contributions Policy
+
+Artificial intelligence systems raise many questions around copyright that have
+yet to be answered. As per the [GitHub TOS](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license), contributors are responsible for ensuring that they have the 
+right to contribute code under the terms of the repository license. Using AI tools to
+regenerate copyrighted material does not remove the copyright, and contributors
+are responsible for ensuring that such material does not appear in their
+contributions. Violations will be dealt with according to our [IP violation policy](./INTELLECTUAL_PROPERTY_VIOLATION_POLICY.md).
+
+In short, MapLibre's policy on AI generated contributions is that contributors are permitted to
+use artificial intelligence tools to produce contributions, provided that they have the right
+to license that code under the relevant license.
+
+While MapLibre has a liberal policy on AI tool use, contributors are
+considered responsible for their contributions. We encourage contributors to
+review all generated code before sending it for review to verify its
+correctness and to understand it so that they can answer questions during code
+review. Reviewing and maintaining generated code that the original contributor
+does not understand is not a good use of limited project resources.
+
+<!-- This AI policy was adapted from clang's AI generated contributions policy -->
+<!-- See https://github.com/llvm/llvm-project/pull/91014 -->
+<!-- License: Apache License Version 2.0 -->


### PR DESCRIPTION
This policy was adopted from [Clang's AI Generated Contributions Policy](https://github.com/llvm/llvm-project/pull/91014), as indicated in the comment in the file.