### PR TITLE
Add link to AI Policy in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <https://www.maplibre.org/>
 
-This repository contains various documents that define the MapLibre Organization such as the Charter, our Code of Conduct, the list of Voting Members, and more.
+This repository contains various documents that define the MapLibre Organization such as the Charter, our Code of Conduct, the list of Voting Members, and [MapLibre's AI Policy](/AI_POLICY.md).
 
 You also find here the results of past Governing Board elections.
 


### PR DESCRIPTION
Brief mention in the README to acknowledge that this is the place where our org-wide AI Policy is stored.