### PR TITLE
Add @mikestvz to voting members list

### DIFF
--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -142,6 +142,8 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@Miguel-Sanches](https://github.com/Miguel-Sanches) (one.network)
 
+[@mikestvz](https://github.com/mikestvz) (AWS)
+
 [@mnutt](https://github.com/mnutt) (Movable Ink)
 
 [@mojodna](https://github.com/mojodna) (AWS)


### PR DESCRIPTION
I would like to nominate @mikestvz to become a MapLibre Voting Member.

## Motivation

Coordinator for MapLibre from a key sponsoring organisation

## Checklist

- [x] The nominee contributed in a non-trivial way or donated funds to the MapLibre Organization.
- [x] This PR updates `VOTING_MEMBERS.md` with the GitHub handle and current employer (when applicable) of the nominee.
- [ ] The nominee has approved the pull request to indicate they want to be a Voting Member of MapLibre.
- [ ] The nominee has shared their full name and contact e-mail with [this form](https://share-eu1.hsforms.com/1OcrNFreTRMqPRb0_PlOt3gfn2ab).
- [ ] At the voting deadline[^1], more [Voting Members](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md) have approved this pull request than disapproved this pull request.

More details on the process of nominating Voting Members can be found [here](https://github.com/maplibre/maplibre/issues/506).

[^1]: Thursday, Aug 20th, 2026 at 17:00 CEST
