### PR TITLE
add @yutannihilation as a voting member

### DIFF
--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -282,6 +282,8 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@yousifd](https://github.com/yousifd) (HudHud)
 
+[@yutannihilation](https://github.com/yutannihilation)
+
 [@ZeLonewolf](https://github.com/ZeLonewolf)
 
 [@zhangyiatmicrosoft](https://github.com/zhangyiatmicrosoft) (Microsoft)


### PR DESCRIPTION
I would like to nominate @yutannihilation to become a MapLibre Voting Member.

## Motivation

Lots of work (+debugging, ..) towards more font support beyond 0xFFFF ( https://github.com/maplibre/martin/pull/2438 , ...).
Good work and thanks for fixing the bugs that we uncovered during this!

## Checklist

- [x] The nominee contributed in a non-trivial way or donated funds to the MapLibre Organization.
- [x] This PR updates `VOTING_MEMBERS.md` with the GitHub handle and current employer (when applicable) of the nominee.
- [ ] The nominee has approved the pull request to indicate they want to be a Voting Member of MapLibre.
- [ ] The nominee has shared their full name and contact e-mail with [this form](https://share-eu1.hsforms.com/1OcrNFreTRMqPRb0_PlOt3gfn2ab).
- [ ] At the voting deadline[^1], more [Voting Members](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md) have approved this pull request than disapproved this pull request.

More details on the process of nominating Voting Members can be found [here](https://github.com/maplibre/maplibre/issues/446).

[^1]: Thursday, Aug 20th, 2026 at 17:00 CEST
