### PR TITLE
Add @1ec5 to voting members list

### DIFF
--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -6,6 +6,8 @@ This file lists all MapLibre Voting Members. See the [Charter](https://github.co
 
 The Voting Members, in alphabetic order by their GitHub handles, are:
 
+[@1ec5](https://github.com/1ec5)
+
 [@AtlasProgramming](https://github.com/AtlasProgramming)
 
 [@adrian-cojocaru](https://github.com/adrian-cojocaru) (AWS)


### PR DESCRIPTION
I would like to nominate @1ec5 to become a MapLibre Voting Member.

## Motivation

<!-- Explain here why you believe your nominee should be a Voting Member. -->
Minh has been an active member in the MapLibre community for a long time, for example by driving many discussions on style spec changes. He is one of the driving forces behind the OpenStreetMap Americana project, which we are very thankful for (especially when benchmarking, since it is quite a heavy style :wink:).

## Checklist

- [x] The nominee contributed in a non-trivial way or donated funds to the MapLibre Organization.
- [x] This PR updates `VOTING_MEMBERS.md` with the GitHub handle and current employer (when applicable) of the nominee.
- [x] The nominee has approved the pull request to indicate they want to be a Voting Member of MapLibre.
- [ ] The nominee has shared their full name and contact e-mail with [this form](https://share-eu1.hsforms.com/1OcrNFreTRMqPRb0_PlOt3gfn2ab).
- [ ] At the voting deadline[^1], more [Voting Members](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md) have approved this pull request than disapproved this pull request.

More details on the process of nominating Voting Members can be found [here](https://github.com/maplibre/maplibre/issues/446).

[^1]: Thursday, Aug 20th, 2026 at 17:00 CEST
