### PR TITLE
add @thomfuhrmann as a voting member

### DIFF
--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -244,6 +244,8 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@thehoneymad](https://github.com/thehoneymad) (AWS)
 
+[@thomfuhrmann](https://github.com/thomfuhrmann)
+
 [@TimSylvester](https://github.com/TimSylvester) (Wet Dog Weather)
 
 [@tjulien](https://github.com/tjulien) (Radar Labs, Inc.)


### PR DESCRIPTION
I would like to nominate @thomfuhrmann to become a MapLibre Voting Member.

## Motivation

Worked making the (now shipped) geojson backend proposed by @styrowolf production grade and shippable.
Second time is a charm, but would not have happend without you both I think.

## Checklist

- [x] The nominee contributed in a non-trivial way or donated funds to the MapLibre Organization.
- [x] This PR updates `VOTING_MEMBERS.md` with the GitHub handle and current employer (when applicable) of the nominee.
- [ ] The nominee has approved the pull request to indicate they want to be a Voting Member of MapLibre.
- [ ] The nominee has shared their full name and contact e-mail with [this form](https://share-eu1.hsforms.com/1OcrNFreTRMqPRb0_PlOt3gfn2ab).
- [ ] At the voting deadline[^1], more [Voting Members](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md) have approved this pull request than disapproved this pull request.

More details on the process of nominating Voting Members can be found [here](https://github.com/maplibre/maplibre/issues/446).

[^1]: Thursday, Aug 20th, 2026 at 17:00 CEST
