### PR TITLE
add @Turtelll as a voting member

### DIFF
--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -248,8 +248,6 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@tjulien](https://github.com/tjulien) (Radar Labs, Inc.)
 
-[@Turtelll](https://github.com/Turtelll)
-
 [@todtb](https://github.com/todtb)
 
 [@tomeronen](https://github.com/tomeronen)
@@ -259,6 +257,8 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 [@tordans](https://github.com/tordans) (FixMyCity GmbH)
 
 [@Tristramg](https://github.com/Tristramg) (Codeurs en Liberté)
+
+[@Turtelll](https://github.com/Turtelll)
 
 [@typebrook](https://github.com/typebrook)
 

--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -248,6 +248,8 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@tjulien](https://github.com/tjulien) (Radar Labs, Inc.)
 
+[@Turtelll](https://github.com/Turtelll)
+
 [@todtb](https://github.com/todtb)
 
 [@tomeronen](https://github.com/tomeronen)


### PR DESCRIPTION
I would like to nominate @Turtelll to become a MapLibre Voting Member.

## Motivation

Basically (re-)implmented the maplibre-tile-spec typescript decoder and did lots of great work around.

## Checklist

- [x] The nominee contributed in a non-trivial way or donated funds to the MapLibre Organization.
- [x] This PR updates `VOTING_MEMBERS.md` with the GitHub handle and current employer (when applicable) of the nominee.
- [x] The nominee has approved the pull request to indicate they want to be a Voting Member of MapLibre.
- [ ] The nominee has shared their full name and contact e-mail with [this form](https://share-eu1.hsforms.com/1OcrNFreTRMqPRb0_PlOt3gfn2ab).
- [ ] At the voting deadline[^1], more [Voting Members](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md) have approved this pull request than disapproved this pull request.

More details on the process of nominating Voting Members can be found [here](https://github.com/maplibre/maplibre/issues/446).

[^1]: Thursday, Aug 20th, 2026 at 17:00 CEST
