### PR TITLE
add @DoFabien as a voting member

### DIFF
--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -60,6 +60,8 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@duje](https://github.com/duje)
 
+[@DoFabien](https://github.com/DoFabien)
+
 [@ebrelsford](https://github.com/ebrelsford) (Stamen)
 
 [@Fabi755](https://github.com/Fabi755)

--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -56,11 +56,11 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@dennemark](https://github.com/dennemark) (Form Follows You)
 
+[@DoFabien](https://github.com/DoFabien)
+
 [@drwestco](https://github.com/drwestco) (Microsoft)
 
 [@duje](https://github.com/duje)
-
-[@DoFabien](https://github.com/DoFabien)
 
 [@ebrelsford](https://github.com/ebrelsford) (Stamen)
 


### PR DESCRIPTION
I would like to nominate @DoFabien to become a MapLibre Voting Member.

## Motivation

FastPFOR encoder/decoder support and lots of great performance improvements to gl-js and tile spec.
Too much for 1-2 sentences really.

## Checklist

- [x] The nominee contributed in a non-trivial way or donated funds to the MapLibre Organization.
- [x] This PR updates `VOTING_MEMBERS.md` with the GitHub handle and current employer (when applicable) of the nominee.
- [ ] The nominee has approved the pull request to indicate they want to be a Voting Member of MapLibre.
- [ ] The nominee has shared their full name and contact e-mail with [this form](https://share-eu1.hsforms.com/1OcrNFreTRMqPRb0_PlOt3gfn2ab).
- [ ] At the voting deadline[^1], more [Voting Members](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md) have approved this pull request than disapproved this pull request.

More details on the process of nominating Voting Members can be found [here](https://github.com/maplibre/maplibre/issues/446).

[^1]: Thursday, Aug 20th, 2026 at 17:00 CEST
