### PR TITLE
add @candux as a voting member

### DIFF
--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -38,6 +38,8 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@brendan-ward](https://github.com/brendan-ward) (self-employed, some time covered by client contracts)
 
+[@candux](https://github.com/candux)
+
 [@caspg](https://github.com/caspg)
 
 [@chippieTV](https://github.com/chippieTV)


### PR DESCRIPTION
I would like to nominate @candux to become a MapLibre Voting Member.

## Motivation

Compression support in the mlt cli, fsst performance fixes, pmtiles+geographic headers, ...
A wider set of things really

## Checklist

- [x] The nominee contributed in a non-trivial way or donated funds to the MapLibre Organization.
- [x] This PR updates `VOTING_MEMBERS.md` with the GitHub handle and current employer (when applicable) of the nominee.
- [x] The nominee has approved the pull request to indicate they want to be a Voting Member of MapLibre.
- [ ] The nominee has shared their full name and contact e-mail with [this form](https://share-eu1.hsforms.com/1OcrNFreTRMqPRb0_PlOt3gfn2ab).
- [ ] At the voting deadline[^1], more [Voting Members](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md) have approved this pull request than disapproved this pull request.

More details on the process of nominating Voting Members can be found [here](https://github.com/maplibre/maplibre/issues/446).

[^1]: Thursday, Aug 20th, 2026 at 17:00 CEST
