### PR TITLE
Fix markdownlint config syntax

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -226,6 +226,5 @@ MD052: true
 # MD053/link-image-reference-definitions - Link and image reference definitions should be needed
 MD053:
   # Ignored definitions
-  ignored_definitions: [
-    "//"
-  ]
+  ignored_definitions:
+    - "//"


### PR DESCRIPTION
This issue was causing the markdownlint check to fail.