### PR TITLE
add @yuiseki as voting member

### DIFF
--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -282,7 +282,7 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@yousifd](https://github.com/yousifd) (HudHud)
 
-[@yuiseki](https://github.com/yuiseki)
+[@yuiseki](https://github.com/yuiseki) (Geolonia)
 
 [@ZeLonewolf](https://github.com/ZeLonewolf)
 

--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -282,6 +282,8 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@yousifd](https://github.com/yousifd) (HudHud)
 
+[@yuiseki](https://github.com/yuiseki)
+
 [@ZeLonewolf](https://github.com/ZeLonewolf)
 
 [@zhangyiatmicrosoft](https://github.com/zhangyiatmicrosoft) (Microsoft)


### PR DESCRIPTION
I would like to nominate @yuiseki to become a MapLibre Voting Member.

## Motivation

@yuiseki has kindly contributed the [MapLibre Native Slint](https://github.com/maplibre/maplibre-native-slint) SDK to the MapLibre Organization, and continue to lead this effort.

Slint is a cross-platform solution, that allow for building native apps with C++/Rust, using MapLibre Native's new WebGPU backend.

## Checklist

- [X] The nominee contributed in a non-trivial way or donated funds to the MapLibre Organization.
- [X] This PR updates `VOTING_MEMBERS.md` with the GitHub handle and current employer (when applicable) of the nominee.
- [X] The nominee has approved the pull request to indicate they want to be a Voting Member of MapLibre.
- [ ] The nominee has shared their full name and contact e-mail with [this form](https://share-eu1.hsforms.com/1OcrNFreTRMqPRb0_PlOt3gfn2ab).
- [ ] At the voting deadline[^1], more [Voting Members](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md) have approved this pull request than disapproved this pull request.

More details on the process of nominating Voting Members can be found [here](https://github.com/maplibre/maplibre/issues/446).

[^1]: Thursday, Aug 20th, 2026 at 17:00 CEST
