### PR TITLE
Add @mizmay to voting members list

### DIFF
--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -142,6 +142,8 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@Miguel-Sanches](https://github.com/Miguel-Sanches) (one.network)
 
+[@mizmay](https://github.com/mizmay)
+
 [@mnutt](https://github.com/mnutt) (Movable Ink)
 
 [@msbarry](https://github.com/msbarry)


### PR DESCRIPTION
Reverts maplibre/maplibre#530 which was accidentally merged too early.

I would like to nominate @mizmay to become a MapLibre Voting Member.

## Motivation

Lots of design input, lots of talks, great vibes and the new zoomsnap feature in gl-js.

## Checklist

- [x] The nominee contributed in a non-trivial way or donated funds to the MapLibre Organization.
- [x] This PR updates `VOTING_MEMBERS.md` with the GitHub handle and current employer (when applicable) of the nominee.
- [x] The nominee has approved the pull request to indicate they want to be a Voting Member of MapLibre.
- [x] The nominee has shared their full name and contact e-mail with [this form](https://share-eu1.hsforms.com/1OcrNFreTRMqPRb0_PlOt3gfn2ab).
- [ ] At the voting deadline[^1], more [Voting Members](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md) have approved this pull request than disapproved this pull request.

More details on the process of nominating Voting Members can be found [here](https://github.com/maplibre/maplibre/issues/446).

[^1]: Thursday, Aug 15th, 2026 at 17:00 CEST
