### PR TITLE
update organization to smellman

### DIFF
--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -220,7 +220,7 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@sjoerdperfors](https://github.com/sjoerdperfors) (Flitsmeister)
 
-[@smellman](https://github.com/smellman)
+[@smellman](https://github.com/smellman) (Geolonia)
 
 [@smellyshovel](https://github.com/smellyshovel)
 


### PR DESCRIPTION
> If Voting Members are paid by a Third-party Organization for their work on the MapLibre Projects, they shall declare publicly who their employer is. At most 10 percent of the Voting Members shall be employed by a single Third-party Organization.

I heard about this from @yuiseki, and I realized I forgot to disclose my organization.
@yuiseki and I both work at Geolonia, where we follow a 20% rule for contributing to open source projects.