### PR TITLE
Nominate xavierjs as a Voting Member

### DIFF
--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -280,6 +280,8 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@xabbu42](https://github.com/xabbu42) (localsearch)
 
+[@xavierjs](https://github.com/xavierjs) (Palantir Technologies)
+
 [@yousifd](https://github.com/yousifd) (HudHud)
 
 [@ZeLonewolf](https://github.com/ZeLonewolf)


### PR DESCRIPTION
I would like to nominate @xavierjs to become a MapLibre Voting Member.

## Motivation

I have contributed to MapLibre GL JS, mainly by working on WebGL performance optimizations. I would like to continue contributing and help ensure that MapLibre’s performance continues to improve. Joining the voting committee would allow me to support the project’s technical direction and long-term growth.

* PRs on Maplibre GLJS main repo: https://github.com/maplibre/maplibre-gl-js/pulls?q=is%3Apr+author%3Axavierjs+
* PR on Maplibre Style Spec: https://github.com/maplibre/maplibre-style-spec/pull/1712
* PR on Mapbox TinySDF: https://github.com/mapbox/tiny-sdf/pull/61

## Checklist

- [X] The nominee contributed in a non-trivial way or donated funds to the MapLibre Organization.
- [X] This PR updates `VOTING_MEMBERS.md` with the GitHub handle and current employer (when applicable) of the nominee.
- [X] The nominee has approved the pull request to indicate they want to be a Voting Member of MapLibre.
- [X] The nominee has shared their full name and contact e-mail with [this form](https://share-eu1.hsforms.com/1OcrNFreTRMqPRb0_PlOt3gfn2ab).
- [x] At the voting deadline[^1], more [Voting Members](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md) have approved this pull request than disapproved this pull request.

More details on the process of nominating Voting Members can be found [here](https://github.com/maplibre/maplibre/issues/446).

[^1]: Thursday, Aug 20th, 2026 at 17:00 CEST
