### PR TITLE
Add @ekamp to the list of voting members

### DIFF
--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -8,8 +8,6 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@acalcutt](https://github.com/acalcutt)
 
-[@ekamp](https://github.com/ekamp) (Lyft)
-
 [@adrian-cojocaru](https://github.com/adrian-cojocaru) (AWS)
 
 [@alanchenboy](https://github.com/alanchenboy) (Grab Technology (Beijing) Co., Ltd.)
@@ -63,6 +61,8 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 [@duje](https://github.com/duje)
 
 [@ebrelsford](https://github.com/ebrelsford) (Stamen)
+
+[@ekamp](https://github.com/ekamp) (Lyft)
 
 [@Fabi755](https://github.com/Fabi755)
 

--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -8,6 +8,8 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@acalcutt](https://github.com/acalcutt)
 
+[@ekamp](https://github.com/ekamp) (Lyft)
+
 [@adrian-cojocaru](https://github.com/adrian-cojocaru) (AWS)
 
 [@alanchenboy](https://github.com/alanchenboy) (Grab Technology (Beijing) Co., Ltd.)


### PR DESCRIPTION
I would like to nominate @ekamp to become a MapLibre Voting Member.

## Motivation

<!-- Explain here why you believe your nominee should be a Voting Member. -->
Helped [testing](https://github.com/maplibre/maplibre-native/issues?q=is%3Aissue%20state%3Aclosed%20author%3Aekamp) early versions of the Vulkan backend for MapLibre Android at Lyft. Active participation in TSC Meetings.

## Checklist

- [x] The nominee contributed in a non-trivial way or donated funds to the MapLibre Organization.
- [x] This PR updates `VOTING_MEMBERS.md` with the GitHub handle and current employer (when applicable) of the nominee.
- [x] The nominee has approved the pull request to indicate they want to be a Voting Member of MapLibre.
- [x] The nominee has shared their full name and contact e-mail with [this form](https://share-eu1.hsforms.com/1OcrNFreTRMqPRb0_PlOt3gfn2ab).
- [ ] At the voting deadline[^1], more [Voting Members](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md) have approved this pull request than disapproved this pull request.

More details on the process of nominating Voting Members can be found [here](https://github.com/maplibre/maplibre/issues/446).

[^1]: Thursday, Aug 20th, 2026 at 17:00 CEST
