### PR TITLE
Nominate @melitele as a MapLibre Voting Member

### DIFF
--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -138,6 +138,8 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@maxammann](https://github.com/maxammann)
 
+[@melitele](https://github.com/melitele) (furkot)
+
 [@michaelkirk](https://github.com/michaelkirk)
 
 [@Miguel-Sanches](https://github.com/Miguel-Sanches) (one.network)


### PR DESCRIPTION
I would like to nominate @melitele to become a MapLibre Voting Member.

## Motivation

implemented global-state in most of the places (pain, layout, patterns, visibility) and tons of similar refactorings

## Checklist

- [x] The nominee contributed in a non-trivial way or donated funds to the MapLibre Organization.
- [x] This PR updates `VOTING_MEMBERS.md` with the GitHub handle and current employer (when applicable) of the nominee.
- [x] The nominee has approved the pull request to indicate they want to be a Voting Member of MapLibre.
- [ ] The nominee has shared their full name and contact e-mail with [this form](https://share-eu1.hsforms.com/1OcrNFreTRMqPRb0_PlOt3gfn2ab).
- [ ] At the voting deadline[^1], more [Voting Members](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md) have approved this pull request than disapproved this pull request.

More details on the process of nominating Voting Members can be found [here](https://github.com/maplibre/maplibre/issues/446).

[^1]: Thursday, Aug 20th, 2026 at 17:00 CEST
