### PR TITLE
Nominate @johanrd as a MapLibre Voting Member

### DIFF
--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -94,6 +94,8 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@jleedev](https://github.com/jleedev)
 
+[@johanrd](https://github.com/johanrd) (Fremby AS)
+
 [@jonahadkins](https://github.com/jonahadkins) (Meta)
 
 [@JonasVautherin](https://github.com/JonasVautherin) (Auterion)

--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -116,9 +116,9 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@jleedev](https://github.com/jleedev)
 
-[@johncarmack1984](https://github.com/johncarmack1984)
-
 [@johanrd](https://github.com/johanrd) (Fremby AS)
+
+[@johncarmack1984](https://github.com/johncarmack1984)
 
 [@jonahadkins](https://github.com/jonahadkins) (Meta)
 


### PR DESCRIPTION
I would like to nominate @johanrd to become a MapLibre Voting Member.

## Motivation

Systematic memory-leak campaign over most of gl-js interfaces, baseline-legacy cleanups, ...

## Checklist

- [x] The nominee contributed in a non-trivial way or donated funds to the MapLibre Organization.
- [x] This PR updates `VOTING_MEMBERS.md` with the GitHub handle and current employer (when applicable) of the nominee.
- [x] The nominee has approved the pull request to indicate they want to be a Voting Member of MapLibre.
- [x] The nominee has shared their full name and contact e-mail with [this form](https://share-eu1.hsforms.com/1OcrNFreTRMqPRb0_PlOt3gfn2ab).
- [ ] At the voting deadline[^1], more [Voting Members](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md) have approved this pull request than disapproved this pull request.

More details on the process of nominating Voting Members can be found [here](https://github.com/maplibre/maplibre/issues/446).

[^1]: Thursday, Aug 20th, 2026 at 17:00 CEST
