### PR TITLE
Nominate @bjperson as a MapLibre Voting Member

### DIFF
--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -34,6 +34,8 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@birkskyum](https://github.com/birkskyum)
 
+[@bjperson](https://github.com/bjperson)
+
 [@boldtrn](https://github.com/boldtrn) (Kurviger)
 
 [@brendan-ward](https://github.com/brendan-ward) (self-employed, some time covered by client contracts)


### PR DESCRIPTION
I would like to nominate @bjperson to become a MapLibre Voting Member.

## Motivation

implmented the time controll utilities allowing precice controll of time in tests and production

## Checklist

- [x] The nominee contributed in a non-trivial way or donated funds to the MapLibre Organization.
- [x] This PR updates `VOTING_MEMBERS.md` with the GitHub handle and current employer (when applicable) of the nominee.
- [x] The nominee has approved the pull request to indicate they want to be a Voting Member of MapLibre.
- [x] The nominee has shared their full name and contact e-mail with [this form](https://share-eu1.hsforms.com/1OcrNFreTRMqPRb0_PlOt3gfn2ab).
- [ ] At the voting deadline[^1], more [Voting Members](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md) have approved this pull request than disapproved this pull request.

More details on the process of nominating Voting Members can be found [here](https://github.com/maplibre/maplibre/issues/446).

[^1]: Thursday, Aug 20th, 2026 at 17:00 CEST
