### PR TITLE
Nominate @mondsichtung as a MapLibre Voting Member

### DIFF
--- a/VOTING_MEMBERS.md
+++ b/VOTING_MEMBERS.md
@@ -144,6 +144,8 @@ The Voting Members, in alphabetic order by their GitHub handles, are:
 
 [@mnutt](https://github.com/mnutt) (Movable Ink)
 
+[@mondsichtung](https://github.com/mondsichtung)
+
 [@msbarry](https://github.com/msbarry)
 
 [@muesliq](https://github.com/muesliq) (Maptoolkit)


### PR DESCRIPTION
I would like to nominate @mondsichtung to become a MapLibre Voting Member.

## Motivation

hipped ImageSource decoded-image updates, globe zoom pointer handling, memory leak handling, ...

## Checklist

- [x] The nominee contributed in a non-trivial way or donated funds to the MapLibre Organization.
- [x] This PR updates `VOTING_MEMBERS.md` with the GitHub handle and current employer (when applicable) of the nominee.
- [x] The nominee has approved the pull request to indicate they want to be a Voting Member of MapLibre.
- [x] The nominee has shared their full name and contact e-mail with [this form](https://share-eu1.hsforms.com/1OcrNFreTRMqPRb0_PlOt3gfn2ab).
- [ ] At the voting deadline[^1], more [Voting Members](https://github.com/maplibre/maplibre/blob/main/VOTING_MEMBERS.md) have approved this pull request than disapproved this pull request.

More details on the process of nominating Voting Members can be found [here](https://github.com/maplibre/maplibre/issues/446).

[^1]: Thursday, Aug 20th, 2026 at 17:00 CEST
